### PR TITLE
DM-15707: Prototype translation infrastructure

### DIFF
--- a/python/lsst/obs/metadata/metadata.py
+++ b/python/lsst/obs/metadata/metadata.py
@@ -75,11 +75,11 @@ class MetadataMeta(type):
 
         for standardKey, fitsKey in self._unitMap.items():
             translator = self._makeUnitMapping(standardKey, fitsKey)
-            setattr(self, f"to{standardKey.capitalize()}", staticmethod(translator))
+            setattr(self, f"to_{standardKey}", staticmethod(translator))
 
         for standardKey, constant in self._constMap.items():
             translator = self._makeConstMapping(standardKey, constant)
-            setattr(self, f"to{standardKey.capitalize()}", staticmethod(translator))
+            setattr(self, f"to_{standardKey}", staticmethod(translator))
 
 
 class MetadataTranslator(metaclass=MetadataMeta):
@@ -168,7 +168,7 @@ class VisitInfo:
         translations = ("telescope", "instrument", "datetime_begin", "datetime_end")
         for t in translations:
             # prototype code
-            method = f"to{t.capitalize()}"
+            method = f"to_{t}"
             property = f"_{t}"
 
             try:

--- a/python/lsst/obs/metadata/metadata.py
+++ b/python/lsst/obs/metadata/metadata.py
@@ -49,7 +49,7 @@ class MetadataMeta(type):
         return translator
 
     @staticmethod
-    def _makeUnitMapping(standardKey, fitsKey):
+    def _makeTrivialMapping(standardKey, fitsKey):
         def translator(header):
             return header[fitsKey]
         translator.__doc__ = f"""Map '{fitsKey}' FITS keyword to '{standardKey}' property
@@ -73,8 +73,8 @@ class MetadataMeta(type):
         if hasattr(self, "name") and self.name is not None:
             MetadataTranslator.translators[self.name] = self
 
-        for standardKey, fitsKey in self._unitMap.items():
-            translator = self._makeUnitMapping(standardKey, fitsKey)
+        for standardKey, fitsKey in self._trivialMap.items():
+            translator = self._makeTrivialMapping(standardKey, fitsKey)
             setattr(self, f"to_{standardKey}", staticmethod(translator))
 
         for standardKey, constant in self._constMap.items():
@@ -85,7 +85,7 @@ class MetadataMeta(type):
 class MetadataTranslator(metaclass=MetadataMeta):
     """Per-instrument metadata translation support"""
 
-    _unitMap = {}
+    _trivialMap = {}
     """Dict of one-to-one mappings for header translation from standard
     property to corresponding FITS keyword."""
 

--- a/python/lsst/obs/metadata/metadata.py
+++ b/python/lsst/obs/metadata/metadata.py
@@ -43,8 +43,8 @@ class MetadataMeta(type):
 
         Returns
         -------
-        translation : `str` or `numbers.Number`
-            Always returns {constant}.
+        translation : `{type(constant).__name__}`
+            Always returns {constant!r}.
         """
         return translator
 

--- a/python/lsst/obs/metadata/metadata.py
+++ b/python/lsst/obs/metadata/metadata.py
@@ -71,8 +71,6 @@ class MetadataMeta(type):
         super().__init__(name, bases, dct)
 
         if hasattr(self, "name") and self.name is not None:
-            print(f"Assigning {self.name}")
-            print("translators:", MetadataTranslator.translators)
             MetadataTranslator.translators[self.name] = self
 
         for standardKey, fitsKey in self._unitMap.items():
@@ -160,7 +158,7 @@ class VisitInfo:
             try:
                 print(f"Assigning {property} via {method}")
                 setattr(self, property, getattr(translator, method)(header))
-            except AttributeError:
+            except (AttributeError, KeyError):
                 # For now assign None
                 setattr(self, property, None)
 

--- a/python/lsst/obs/metadata/metadata.py
+++ b/python/lsst/obs/metadata/metadata.py
@@ -1,0 +1,181 @@
+# This file is part of obs_metadata.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (http://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Classes and support code for metadata translation"""
+
+from abc import abstractmethod
+import logging
+
+log = logging.getLogger(__name__)
+
+
+class MetadataMeta(type):
+    """Register all subclasses with the base class"""
+
+    @staticmethod
+    def _makeConstMapping(standardKey, constant):
+        def translator(header):
+            return constant
+        translator.__doc__ = f"""Returns constant value for '{standardKey}' property
+
+        Parameters
+        ----------
+        header : `dict`-like
+            Header values representing a FITS header.
+
+        Returns
+        -------
+        translation : `str` or `numbers.Number`
+            Always returns {constant}.
+        """
+        return translator
+
+    @staticmethod
+    def _makeUnitMapping(standardKey, fitsKey):
+        def translator(header):
+            return header[fitsKey]
+        translator.__doc__ = f"""Map '{fitsKey}' FITS keyword to '{standardKey}' property
+
+        Parameters
+        ----------
+        header : `dict`-like
+            Header values representing a FITS header.
+
+        Returns
+        -------
+        translation : `str` or `numbers.Number`
+            Translated header value derived directly from the {fitsKey}
+            header value.
+        """
+        return translator
+
+    def __init__(self, name, bases, dct):
+        super().__init__(name, bases, dct)
+
+        if hasattr(self, "name") and self.name is not None:
+            print(f"Assigning {self.name}")
+            print("translators:", MetadataTranslator.translators)
+            MetadataTranslator.translators[self.name] = self
+
+        for standardKey, fitsKey in self._unitMap.items():
+            translator = self._makeUnitMapping(standardKey, fitsKey)
+            setattr(self, f"to{standardKey.capitalize()}", staticmethod(translator))
+
+        for standardKey, constant in self._constMap.items():
+            translator = self._makeConstMapping(standardKey, constant)
+            setattr(self, f"to{standardKey.capitalize()}", staticmethod(translator))
+
+
+class MetadataTranslator(metaclass=MetadataMeta):
+    """Per-instrument metadata translation support"""
+
+    _unitMap = {}
+    """Dict of one-to-one mappings for header translation from standard
+    property to corresponding FITS keyword."""
+
+    _constMap = {}
+    """Dict defining a constant for specified standard properties."""
+
+    translators = dict()
+    """All registered metadata translation classes."""
+
+    supportedInstrument = None
+    """Name of instrument understood by this translation class."""
+
+    @classmethod
+    @abstractmethod
+    def canTranslate(cls, header):
+        """Indicate whether this translation class can translate the
+        supplied header.
+
+        Parameters
+        ----------
+        header : `dict`-like
+           Header to convert to standardized form.
+
+        Returns
+        -------
+        can : `bool`
+            `True` if the header is recognized by this class. `False`
+            otherwise.
+        """
+        raise NotImplementedError()
+
+
+class VisitInfo:
+    """Standardized representation of an instrument FITS header.
+
+    Parameters
+    ----------
+    header : `dict`-like
+        Representation of an instrument FITS header accessible as a `dict`.
+    translator : `MetadataTranslator`-class, `optional`
+        If not `None`, the class to use to translate the supplied headers
+        into standard form. Otherwise each registered translator class will
+        be asked in turn if it knows how to translate the supplied header.
+
+    Raises
+    ------
+    ValueError
+        The supplied header was not recognized by any of the registered
+        translators.
+    """
+
+    def __init__(self, header, translator=None):
+        if translator is None:
+            for name, trans in MetadataTranslator.translators.items():
+                if trans.canTranslate(header):
+                    log.debug(f"Using translation class {name}")
+                    translator = trans
+                    break
+            else:
+                raise ValueError("None of the registered translation classes understood this header")
+
+        # Loop over each translation (not final form -- this should be
+        # defined in one place and consistent with translation classes)
+        translations = ("telescope", "instrument", "datetime_begin", "datetime_end")
+        for t in translations:
+            # prototype code
+            method = f"to{t.capitalize()}"
+            property = f"_{t}"
+
+            try:
+                print(f"Assigning {property} via {method}")
+                setattr(self, property, getattr(translator, method)(header))
+            except AttributeError:
+                # For now assign None
+                setattr(self, property, None)
+
+    @property
+    def datetime_begin(self):
+        return self._datetime_begin
+
+    @property
+    def datetime_end(self):
+        return self._datetime_end
+
+    @property
+    def instrument(self):
+        return self._instrument
+
+    @property
+    def telescope(self):
+        return self._telescope

--- a/python/lsst/obs/metadata/translators/__init__.py
+++ b/python/lsst/obs/metadata/translators/__init__.py
@@ -19,6 +19,4 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from .metadata import *
-from .translators import *
-from .version import *
+from .fits import *

--- a/python/lsst/obs/metadata/translators/fits.py
+++ b/python/lsst/obs/metadata/translators/fits.py
@@ -37,8 +37,8 @@ class FitsTranslator(MetadataTranslator):
     """
 
     # Direct translation from header key to standard form
-    _unitMap = dict(instrument="INSTRUME",
-                    telescope="TELESCOP")
+    _trivialMap = dict(instrument="INSTRUME",
+                       telescope="TELESCOP")
 
     @classmethod
     def canTranslate(cls, header):

--- a/python/lsst/obs/metadata/translators/fits.py
+++ b/python/lsst/obs/metadata/translators/fits.py
@@ -1,0 +1,63 @@
+# This file is part of obs_metadata.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (http://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Metadata translation code for standard FITS headers"""
+from ..metadata import MetadataTranslator
+
+
+class FitsTranslator(MetadataTranslator):
+    """Metadata translator for FITS standard headers.
+
+    Understands:
+
+    - DATE-OBS
+    - INSTRUME
+    - TELESCOP
+
+    """
+
+    # Direct translation from header key to standard form
+    _unitMap = dict(instrument="INSTRUME",
+                    telescope="TELESCOP")
+
+    @classmethod
+    def canTranslate(cls, header):
+        """Indicate whether this translation class can translate the
+        supplied header.
+
+        Checks the instrument value and compares with the supported
+        instruments in the class
+
+        Parameters
+        ----------
+        header : `dict`-like
+           Header to convert to standardized form.
+
+        Returns
+        -------
+        can : `bool`
+            `True` if the header is recognized by this class. `False`
+            otherwise.
+        """
+        if cls.supportedInstrument is None:
+            return False
+
+        return cls.toInstrument(header) == cls.supportedInstrument

--- a/python/lsst/obs/metadata/translators/fits.py
+++ b/python/lsst/obs/metadata/translators/fits.py
@@ -91,8 +91,36 @@ class FitsTranslator(MetadataTranslator):
 
     @staticmethod
     def to_datetime_begin(header):
+        """Calculate start time of observation.
+
+        Uses FITS standard ``DATE-OBS`` and ``TIMESYS`` headers.
+
+        Parameters
+        ----------
+        header : `dict`-like
+            Header values representing a FITS header.
+
+        Returns
+        -------
+        start_time : `astropy.time.Time`
+            Time corresponding to the start of the observation.
+        """
         return FitsTranslator._from_fits_date(header, "DATE-OBS")
 
     @staticmethod
     def to_datetime_end(header):
+        """Calculate end time of observation.
+
+        Uses FITS standard ``DATE-END`` and ``TIMESYS`` headers.
+
+        Parameters
+        ----------
+        header : `dict`-like
+            Header values representing a FITS header.
+
+        Returns
+        -------
+        start_time : `astropy.time.Time`
+            Time corresponding to the end of the observation.
+        """
         return FitsTranslator._from_fits_date(header, "DATE-END")

--- a/python/lsst/obs/metadata/translators/fits.py
+++ b/python/lsst/obs/metadata/translators/fits.py
@@ -62,7 +62,7 @@ class FitsTranslator(MetadataTranslator):
         if cls.supportedInstrument is None:
             return False
 
-        return cls.toInstrument(header) == cls.supportedInstrument
+        return cls.to_instrument(header) == cls.supportedInstrument
 
     @staticmethod
     def _from_fits_date(header, dateKey):
@@ -90,9 +90,9 @@ class FitsTranslator(MetadataTranslator):
         return Time(header[dateKey], format="isot", scale=scale)
 
     @staticmethod
-    def toDatetime_begin(header):
+    def to_datetime_begin(header):
         return FitsTranslator._from_fits_date(header, "DATE-OBS")
 
     @staticmethod
-    def toDatetime_end(header):
+    def to_datetime_end(header):
         return FitsTranslator._from_fits_date(header, "DATE-END")

--- a/python/lsst/obs/metadata/translators/fits.py
+++ b/python/lsst/obs/metadata/translators/fits.py
@@ -20,6 +20,8 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 """Metadata translation code for standard FITS headers"""
+from astropy.time import Time
+
 from ..metadata import MetadataTranslator
 
 
@@ -61,3 +63,36 @@ class FitsTranslator(MetadataTranslator):
             return False
 
         return cls.toInstrument(header) == cls.supportedInstrument
+
+    @staticmethod
+    def _from_fits_date(header, dateKey):
+        """Calculate a date object from the named FITS header
+
+        Uses the TIMESYS header if present to determine the time scale.
+
+        Parameters
+        ----------
+        header : `dict`-like
+            A `dict` representing a FITS-like header.
+        dateKey : `str`
+            The key in the header representing a standard FITS
+            ISO-style date.
+
+        Returns
+        -------
+        date : `astropy.time.Time`
+            `~astropy.time.Time` representation of the date.
+        """
+        if "TIMESYS" in header:
+            scale = header["TIMESYS"]
+        else:
+            scale = "utc"
+        return Time(header[dateKey], format="isot", scale=scale)
+
+    @staticmethod
+    def toDatetime_begin(header):
+        return FitsTranslator._from_fits_date(header, "DATE-OBS")
+
+    @staticmethod
+    def toDatetime_end(header):
+        return FitsTranslator._from_fits_date(header, "DATE-END")

--- a/tests/test_translation.py
+++ b/tests/test_translation.py
@@ -20,6 +20,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import unittest
+from astropy.time import Time
 
 from lsst.obs.metadata import FitsTranslator, VisitInfo
 
@@ -46,6 +47,8 @@ class BasicTestCase(unittest.TestCase):
         self.header = {"TELESCOP": "JCMT",
                        "TELCODE": "LSST",
                        "INSTRUME": "SCUBA_test",
+                       "DATE-OBS": "2000-01-01T01:00:01.500",
+                       "DATE-END": "2000-01-01T02:00:01.500",
                        "BAZ": "bar"}
 
     def testBasicManualTranslation(self):
@@ -56,6 +59,8 @@ class BasicTestCase(unittest.TestCase):
         self.assertFalse(FitsTranslator.canTranslate(header))
         self.assertEqual(FitsTranslator.toTelescope(header), "JCMT")
         self.assertEqual(FitsTranslator.toInstrument(header), "SCUBA_test")
+        self.assertEqual(FitsTranslator.toDatetime_begin(header),
+                         Time(header["DATE-OBS"], format="isot"))
 
         # Use the special test translator instead
         self.assertTrue(TestTranslator.canTranslate(header))
@@ -76,6 +81,7 @@ class BasicTestCase(unittest.TestCase):
         v1 = VisitInfo(header)
         self.assertEqual(v1.instrument, "SCUBA_test")
         self.assertEqual(v1.telescope, "LSST")
+        print(v1.__dict__)
 
 
 if __name__ == "__main__":

--- a/tests/test_translation.py
+++ b/tests/test_translation.py
@@ -57,17 +57,17 @@ class BasicTestCase(unittest.TestCase):
 
         # Treat the header as standard FITS
         self.assertFalse(FitsTranslator.canTranslate(header))
-        self.assertEqual(FitsTranslator.toTelescope(header), "JCMT")
-        self.assertEqual(FitsTranslator.toInstrument(header), "SCUBA_test")
-        self.assertEqual(FitsTranslator.toDatetime_begin(header),
+        self.assertEqual(FitsTranslator.to_telescope(header), "JCMT")
+        self.assertEqual(FitsTranslator.to_instrument(header), "SCUBA_test")
+        self.assertEqual(FitsTranslator.to_datetime_begin(header),
                          Time(header["DATE-OBS"], format="isot"))
 
         # Use the special test translator instead
         self.assertTrue(TestTranslator.canTranslate(header))
-        self.assertEqual(TestTranslator.toTelescope(header), "LSST")
-        self.assertEqual(TestTranslator.toInstrument(header), "SCUBA_test")
-        self.assertEqual(TestTranslator.toFormat(header), "HDF5")
-        self.assertEqual(TestTranslator.toFoobar(header), "bar")
+        self.assertEqual(TestTranslator.to_telescope(header), "LSST")
+        self.assertEqual(TestTranslator.to_instrument(header), "SCUBA_test")
+        self.assertEqual(TestTranslator.to_format(header), "HDF5")
+        self.assertEqual(TestTranslator.to_foobar(header), "bar")
 
     def testBasicTranslator(self):
         header = self.header

--- a/tests/test_translation.py
+++ b/tests/test_translation.py
@@ -1,0 +1,82 @@
+# This file is part of obs_metadata.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (http://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import unittest
+
+from lsst.obs.metadata import FitsTranslator, VisitInfo
+
+
+class TestTranslator(FitsTranslator):
+
+    # Needs a name to be registered
+    name = "TestTranslator"
+
+    # Indicate the instrument this class understands
+    supportedInstrument = "SCUBA_test"
+
+    # Some new mappings, including an override
+    _unitMap = {"foobar": "BAZ",
+                "telescope": "TELCODE"}
+
+    _constMap = {"format": "HDF5"}
+
+
+class BasicTestCase(unittest.TestCase):
+
+    def setUp(self):
+        # Known simple header
+        self.header = {"TELESCOP": "JCMT",
+                       "TELCODE": "LSST",
+                       "INSTRUME": "SCUBA_test",
+                       "BAZ": "bar"}
+
+    def testBasicManualTranslation(self):
+
+        header = self.header
+
+        # Treat the header as standard FITS
+        self.assertFalse(FitsTranslator.canTranslate(header))
+        self.assertEqual(FitsTranslator.toTelescope(header), "JCMT")
+        self.assertEqual(FitsTranslator.toInstrument(header), "SCUBA_test")
+
+        # Use the special test translator instead
+        self.assertTrue(TestTranslator.canTranslate(header))
+        self.assertEqual(TestTranslator.toTelescope(header), "LSST")
+        self.assertEqual(TestTranslator.toInstrument(header), "SCUBA_test")
+        self.assertEqual(TestTranslator.toFormat(header), "HDF5")
+        self.assertEqual(TestTranslator.toFoobar(header), "bar")
+
+    def testBasicTranslator(self):
+        header = self.header
+
+        # Specify a translation class
+        v1 = VisitInfo(header, translator=TestTranslator)
+        self.assertEqual(v1.instrument, "SCUBA_test")
+        self.assertEqual(v1.telescope, "LSST")
+
+        # Now automated class
+        v1 = VisitInfo(header)
+        self.assertEqual(v1.instrument, "SCUBA_test")
+        self.assertEqual(v1.telescope, "LSST")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_translation.py
+++ b/tests/test_translation.py
@@ -34,8 +34,8 @@ class TestTranslator(FitsTranslator):
     supportedInstrument = "SCUBA_test"
 
     # Some new mappings, including an override
-    _unitMap = {"foobar": "BAZ",
-                "telescope": "TELCODE"}
+    _trivialMap = {"foobar": "BAZ",
+                   "telescope": "TELCODE"}
 
     _constMap = {"format": "HDF5"}
 


### PR DESCRIPTION
* Prototype translation class hierarchy. Initial support for standard FITS header translation.
* Automatic translation method creation for simple cases (one to one mappings and constants)
* Automatic detection of translation class to use for a specific header
* Basic test translation class demonstrating usage.

The file layout is not entirely correct yet (mixing VisitInfo and MetadataTranslator classes in a single file). The review question is whether the approach is suitable.

Some questions:

* `toBegin_date` is an odd looking method name to calculate the `begin_date` property. `to_begin_date` would be much more obvious and easier to guess the purpose.
* The header translation methods are currently static methods that take a FITS header. In theory they could be instance methods that use `self._header` but I'm not sure that gains us anything.
