### PR TITLE
DM-18576: Warn if translation methods are shadowing others

### DIFF
--- a/python/astro_metadata_translator/translator.py
+++ b/python/astro_metadata_translator/translator.py
@@ -264,7 +264,7 @@ class MetadataTranslator:
                 header_key = header_key[0]
             translator = cls._make_trivial_mapping(property_key, header_key, **kwargs)
             method = f"to_{property_key}"
-            translator.__name__ = f"{method}_trivial"
+            translator.__name__ = f"{method}_trivial_in_{cls.__name__}"
             setattr(cls, method, cache_translation(translator, method=method))
             if property_key not in PROPERTIES:
                 log.warning(f"Unexpected trivial translator for '{property_key}' defined in {cls}")
@@ -274,7 +274,7 @@ class MetadataTranslator:
         for property_key, constant in cls._const_map.items():
             translator = cls._make_const_mapping(property_key, constant)
             method = f"to_{property_key}"
-            translator.__name__ = f"{method}_constant"
+            translator.__name__ = f"{method}_constant_in_{cls.__name__}"
             setattr(cls, method, translator)
             if property_key not in PROPERTIES:
                 log.warning(f"Unexpected constant translator for '{property_key}' defined in {cls}")

--- a/tests/test_groups.py
+++ b/tests/test_groups.py
@@ -14,7 +14,7 @@ import os.path
 
 from astro_metadata_translator.tests import read_test_file
 from astro_metadata_translator import ObservationGroup
-from astro_metadata_translator.serialize import group_to_fits
+from astro_metadata_translator.serialize import group_to_fits, info_to_fits
 
 TESTDIR = os.path.abspath(os.path.dirname(__file__))
 
@@ -54,6 +54,11 @@ class ObservationGroupTestCase(unittest.TestCase):
         self.assertEqual(newest, sorted_group[-1])
         self.assertEqual(oldest, sorted_group[0])
 
+        self.assertLess(oldest, newest)
+        self.assertGreater(newest, oldest)
+
+        self.assertNotEqual(oldest, obs_group)
+
         # Add some headers and check that sorting still works
         obs_group.extend(self._files_to_headers(self.hsc_files))
         self.assertEqual(len(obs_group), 5)
@@ -76,6 +81,21 @@ class ObservationGroupTestCase(unittest.TestCase):
                     'MJD-END': 57073.034849537034,
                     'DATE-AVG': '2014-01-15T23:28:39.430',
                     'MJD-AVG': 56672.97823413919}
+        self.assertEqual(cards, expected)
+
+    def test_fits_info(self):
+        header = self._files_to_headers(self.decam_files)[0]
+        obs_group = ObservationGroup([header])
+        cards, comments = info_to_fits(obs_group[0])
+
+        expected = {'INSTRUME': 'DECam',
+                    'TIMESYS': 'TAI',
+                    'MJD-AVG': 56536.25417681625,
+                    'MJD-END': 56536.25591435185,
+                    'MJD-OBS': 56536.25243928065,
+                    'DATE-OBS': '2013-09-01T06:03:30.754',
+                    'DATE-AVG': '2013-09-01T06:06:00.877',
+                    'DATE-END': '2013-09-01T06:08:31.000'}
         self.assertEqual(cards, expected)
 
 

--- a/tests/test_shadowing.py
+++ b/tests/test_shadowing.py
@@ -1,0 +1,78 @@
+# This file is part of astro_metadata_translator.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (http://www.lsst.org).
+# See the LICENSE file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# Use of this source code is governed by a 3-clause BSD-style
+# license that can be found in the LICENSE file.
+
+import unittest
+
+from astro_metadata_translator import StubTranslator
+
+
+class ShadowBase(StubTranslator):
+    def to_instrument(self):
+        return "BaseInstrument"
+
+
+class ConstTranslator(StubTranslator):
+    _const_map = {"instrument": "InstrumentB"}
+
+
+class TrivialTranslator(ConstTranslator):
+    # This should not pick up the _const_map from parent class
+    _trivial_map = {"instrument": "INSTRUME"}
+
+
+class ExplicitTranslator(TrivialTranslator):
+    # The explicit method should override the parent implementations
+    # and not inherit the _trivial_map from parent.
+    def to_instrument(self):
+        return "InstrumentE"
+
+
+class TranslatorShadowing(unittest.TestCase):
+
+    def test_shadowing(self):
+
+        with self.assertLogs("astro_metadata_translator", level="WARN") as cm:
+            class ShadowTranslator(StubTranslator):
+                _const_map = {"instrument": "InstrumentC"}
+                _trivial_map = {"instrument": "INSTRUME"}
+
+                def to_instrument(self):
+                    return "Instrument3"
+
+        self.assertIn("defined in both", cm.output[0])
+        self.assertIn("replaced by _const_map", cm.output[1])
+
+        s = ShadowTranslator({})
+        self.assertEqual(s.to_instrument(), "InstrumentC")
+
+        with self.assertLogs("astro_metadata_translator", level="WARN") as cm:
+            class ShadowTranslator(StubTranslator):
+                _trivial_map = {"instrument": "INSTRUME"}
+
+                def to_instrument(self):
+                    return "Instrument3"
+
+        self.assertIn("replaced by _trivial_map", cm.output[0])
+
+        s = ShadowTranslator({"INSTRUME": "InstrumentT"})
+        self.assertEqual(s.to_instrument(), "InstrumentT")
+
+    def test_auto_maps1(self):
+        t = TrivialTranslator({"INSTRUME": "InstrumentX"})
+        self.assertEqual(t.to_instrument(), "InstrumentX")
+
+    def test_auto_maps2(self):
+        t = ExplicitTranslator({})
+        self.assertEqual(t.to_instrument(), "InstrumentE")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
It is possible to define a translation method in const_map, trivial_map and explicitly via `def`.  Now warn if that is happening.  Also if a class was not overriding the trivial/const maps they would get versions from the parent class which could conceivably override the explicit versions in the child.  This now does not happen.