### PR TITLE
DM-19188: Add support for pre-translation header correction

### DIFF
--- a/python/astro_metadata_translator/translator.py
+++ b/python/astro_metadata_translator/translator.py
@@ -531,6 +531,18 @@ class MetadataTranslator:
 
         return True
 
+    def search_paths(self):
+        """Search paths to use when searching for header fix up correction
+        files.
+
+        Returns
+        -------
+        paths : `list`
+            Directory paths to search. Can be an empty list if no special
+            directories are defined.
+        """
+        return []
+
     def is_key_ok(self, keyword):
         """Return `True` if the value associated with the named keyword is
         present in this header and defined.

--- a/tests/data/SCUBA_test-20000101_00002.yaml
+++ b/tests/data/SCUBA_test-20000101_00002.yaml
@@ -1,0 +1,2 @@
+TELCODE: AuxTel
+EXPID: 42


### PR DESCRIPTION
Corrections are applied by locating YAML files named after the instrument/observation_id.