### PR TITLE
DM-16297: Remove PropertyList hack

### DIFF
--- a/python/astro_metadata_translator/headers.py
+++ b/python/astro_metadata_translator/headers.py
@@ -89,9 +89,8 @@ def merge_headers(headers, mode="overwrite", sort=False, first=None, last=None):
     if not headers:
         raise ValueError("No headers supplied.")
 
-    # Force PropertyList to OrderedDict
-    # In python 3.7 dicts are guaranteed to retain order
-    headers = [h.toOrderedDict() if hasattr(h, "toOrderedDict") else h for h in headers]
+    # Copy the input list because we will be reorganizing it
+    headers = list(headers)
 
     # With a single header provided return a copy immediately
     if len(headers) == 1:


### PR DESCRIPTION
Now that PropertySet supports `__getitem__` and `update` there
is no need to convert them to OrderedDict before merging.
This now means that if you request to merge some PropertyList
headers you get back a PropertyList (which is critical if
you then want to pass the result to afw)