### PR TITLE
DM-16297 Revert: "Remove PropertyList hack"

### DIFF
--- a/python/astro_metadata_translator/headers.py
+++ b/python/astro_metadata_translator/headers.py
@@ -89,8 +89,9 @@ def merge_headers(headers, mode="overwrite", sort=False, first=None, last=None):
     if not headers:
         raise ValueError("No headers supplied.")
 
-    # Copy the input list because we will be reorganizing it
-    headers = list(headers)
+    # Force PropertyList to OrderedDict
+    # In python 3.7 dicts are guaranteed to retain order
+    headers = [h.toOrderedDict() if hasattr(h, "toOrderedDict") else h for h in headers]
 
     # With a single header provided return a copy immediately
     if len(headers) == 1:


### PR DESCRIPTION
This reverts commit fb60b34cc7a4993d0aefdcc7af282b70eec78cfc.

This change broke pipe_drivers which assumed that after merging
the resultant object would support the items() method but
PropertyList does not.