### PR TITLE
DM-16297: (take 2) Remove PropertyList hack

### DIFF
--- a/python/astro_metadata_translator/headers.py
+++ b/python/astro_metadata_translator/headers.py
@@ -89,9 +89,8 @@ def merge_headers(headers, mode="overwrite", sort=False, first=None, last=None):
     if not headers:
         raise ValueError("No headers supplied.")
 
-    # Force PropertyList to OrderedDict
-    # In python 3.7 dicts are guaranteed to retain order
-    headers = [h.toOrderedDict() if hasattr(h, "toOrderedDict") else h for h in headers]
+    # Copy the input list because we will be reorganizing it
+    headers = list(headers)
 
     # With a single header provided return a copy immediately
     if len(headers) == 1:
@@ -246,16 +245,9 @@ def fix_header(header, search_path=None, translator_class=None, filename=None):
     The first file located in the search path is used for the correction.
     """
 
-    # PropertyList is not dict-like so force to a dict here to allow the
-    # translation classes to work. We update the original header though.
-    if hasattr(header, "toOrderedDict"):
-        header_to_translate = header.toOrderedDict()
-    else:
-        header_to_translate = header
-
     if translator_class is None:
         try:
-            translator_class = MetadataTranslator.determine_translator(header_to_translate,
+            translator_class = MetadataTranslator.determine_translator(header,
                                                                        filename=filename)
         except ValueError:
             # if the header is not recognized, we should not complain
@@ -265,7 +257,7 @@ def fix_header(header, search_path=None, translator_class=None, filename=None):
         raise TypeError(f"Translator class must be a MetadataTranslator, not {translator_class}")
 
     # Create an instance for this header
-    translator = translator_class(header_to_translate, filename=filename)
+    translator = translator_class(header, filename=filename)
 
     # To determine the file look up we need the observation_id and instrument
     try:

--- a/python/astro_metadata_translator/observationInfo.py
+++ b/python/astro_metadata_translator/observationInfo.py
@@ -95,11 +95,6 @@ class ObservationInfo:
         # Store the supplied header for later stripping
         self._header = header
 
-        # PropertyList is not dict-like so force to a dict here to simplify
-        # the translation code.
-        if hasattr(header, "toOrderedDict"):
-            header = header.toOrderedDict()
-
         if translator_class is None:
             translator_class = MetadataTranslator.determine_translator(header, filename=filename)
         elif not issubclass(translator_class, MetadataTranslator):

--- a/tests/test_headers.py
+++ b/tests/test_headers.py
@@ -68,6 +68,8 @@ class HeadersTestCase(unittest.TestCase):
 
     def test_merging_overwrite(self):
         merged = merge_headers([self.h1, self.h2], mode="overwrite")
+        # The merged header should be the same type as the first header
+        self.assertIsInstance(merged, type(self.h1))
 
         expected = {
             "MJD-OBS": self.h2["MJD-OBS"],


### PR DESCRIPTION
Now that PropertySet supports __getitem__ and update there
is no need to convert them to OrderedDict before merging.
This now means that if you request to merge some PropertyList
headers you get back a PropertyList (which is critical if
you then want to pass the result to afw)

Still have to copy the input list since it is modified
in place.