### PR TITLE
DM-21212: Update existing cp_pipe tasks to pipelineTasks

### DIFF
--- a/python/astro_metadata_translator/translators/suprimecam.py
+++ b/python/astro_metadata_translator/translators/suprimecam.py
@@ -169,9 +169,7 @@ class SuprimeCamTranslator(SubaruTranslator):
         exp : `int`
             Unique visit identifier.
         """
-        if self.to_observation_type() == "science":
-            return self.to_exposure_id()
-        return None
+        return self.to_exposure_id()
 
     @cache_translation
     def to_observation_type(self):


### PR DESCRIPTION
visit_id should be populated for all Subaru data.

The restriction that only science data receive visits is unneeded.  Without this, calibration data cannot be processed by ip_isr.