### PR TITLE
DM-27832: Fatal errors from astro_metadata_translator in DECam

### DIFF
--- a/python/astro_metadata_translator/translators/decam.py
+++ b/python/astro_metadata_translator/translators/decam.py
@@ -253,13 +253,15 @@ class DecamTranslator(FitsTranslator):
         return name[1:]
 
     @classmethod
-    def fix_header(cls, header, obsid, filename=None):
+    def fix_header(cls, header, instrument, obsid, filename=None):
         """Fix DECam headers.
 
         Parameters
         ----------
         header : `dict`
             The header to update.  Updates are in place.
+        instrument : `str`
+            The name of the instrument.
         obsid : `str`
             Unique observation identifier associated with this header.
             Will always be provided.

--- a/tests/test_decam.py
+++ b/tests/test_decam.py
@@ -70,7 +70,7 @@ class DecamTestCase(unittest.TestCase, MetadataAssertHelper):
                            observation_type="zero",
                            observation_reason="unknown",
                            observing_day=20121211,
-                           physical_filter="Y DECam c0005 10095.0 1130.0",
+                           physical_filter="solid plate 0.0 0.0",  # corrected value
                            pressure=777.0*u.hPa,
                            relative_humidity=38.0,
                            science_program="2012B-0416",


### PR DESCRIPTION
The header fixer now fixes headers correctly, and the tests even agree.