### PR TITLE
DM-25965: Workaround single file merge returning PropertyList

### DIFF
--- a/python/astro_metadata_translator/bin/writesidecar.py
+++ b/python/astro_metadata_translator/bin/writesidecar.py
@@ -18,6 +18,22 @@ import traceback
 from ..file_helpers import find_files, read_file_info
 
 
+def _split_ext(file):
+    """Split the extension from the file name and return it and the root.
+
+    Special case handling of .gz and other compression extensions.
+    """
+    special = {".gz", ".bz2", ".xz", ".fz"}
+
+    root, ext = os.path.splitext(file)
+
+    if ext in special:
+        root, second_ext = os.path.splitext(root)
+        ext = second_ext + ext
+
+    return root, ext
+
+
 def write_sidecar_file(file, hdrnum, content_mode, print_trace, outstream=sys.stdout, errstream=sys.stderr):
     """Write JSON summary to sidecar file.
 
@@ -60,8 +76,10 @@ def write_sidecar_file(file, hdrnum, content_mode, print_trace, outstream=sys.st
         if json_str is None:
             return False
 
-        # Calculate file name derived on this file
-        root, ext = os.path.splitext(file)
+        # Calculate sidecar file name derived from this file.
+        # Match the ButlerURI behavior in that .fits.gz should be replaced
+        # with .json, and not resulting in .fits.json.
+        root, ext = _split_ext(file)
         newfile = root + ".json"
         with open(newfile, "w") as fd:
             print(json_str, file=fd)

--- a/python/astro_metadata_translator/indexing.py
+++ b/python/astro_metadata_translator/indexing.py
@@ -13,6 +13,7 @@ __all__ = ("read_index", "calculate_index", "index_files", "process_index_data")
 
 """Functions to support file indexing."""
 
+import collections.abc
 import json
 import logging
 import os
@@ -126,6 +127,12 @@ def calculate_index(headers, content_mode):
 
     # Merge all the information into a primary plus diff
     merged = merge_headers(headers.values(), mode="diff")
+
+    # For a single file it is possible that the merged contents
+    # are not a dict but are an LSST-style PropertyList. JSON needs
+    # dict though.
+    if not isinstance(merged, collections.abc.Mapping):
+        merged = dict(merged)
 
     # The structure to write to file is intended to look like (in YAML):
     # __COMMON__:


### PR DESCRIPTION
If the merged header is not a dict we have to force it to
be a dict to appease JSON.