### PR TITLE
DM-39047: Switch from pkg_resources to importlib.resources

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -33,7 +33,7 @@ jobs:
 
       # We have two cores so we can speed up the testing with xdist
       - name: Install xdist and openfiles
-        run: pip install pytest-xdist pytest-openfiles pytest-flake8 pytest-cov "flake8<5"
+        run: pip install pytest-xdist pytest-openfiles pytest-cov
 
       - name: Install dependencies
         run: pip install -r requirements.txt

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -53,7 +53,7 @@ jobs:
         run: pip install -r doc/requirements.txt
 
       - name: Build documentation
-        run: package-docs build
+        run: package-docs build -n -W
 
       - name: Landing page upload
         if: ${{ github.event_name == 'push' && matrix.python-version == '3.10' }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -53,6 +53,7 @@ jobs:
         run: pip install -r doc/requirements.txt
 
       - name: Build documentation
+        if: ${{ matrix.python-version == '3.10' }}
         run: package-docs build -n -W
 
       - name: Landing page upload

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.9", "3.10", "3.11"]
 
     steps:
       - uses: actions/checkout@v3
@@ -78,7 +78,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.8
+          python-version: "3.10"
           cache: "pip"
           cache-dependency-path: "setup.cfg"
 

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -9,3 +9,8 @@ on:
 jobs:
   call-workflow:
     uses: lsst/rubin_workflows/.github/workflows/lint.yaml@main
+  ruff:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: chartboost/ruff-action@v1

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -24,3 +24,9 @@ except KeyError:
 # mostly work if the Pipelines and astro_metadata_translator are developed
 # concurrently.
 intersphinx_mapping["lsst"] = ("https://pipelines.lsst.io/v/daily/", None)  # noqa
+
+nitpick_ignore_regex = [
+    ("py:.*", r"lsst\..*"),  # Ignore warnings from links to other lsst packages.
+    ("py:class", "(None|item) -- remove.*"),  # MutableSequence
+    ("py:class", "integer -- return.*"),  # Sequence
+]

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -15,7 +15,7 @@ There are header translation classes implemented as subclasses of
 `~astro_metadata_translator.MetadataTranslator`.  These translation subclasses
 implement methods corresponding to each derived property defined in
 `~astro_metadata_translator.ObservationInfo`. The methods are named
-`to_{property}` and can be implemented explicitly by a translation class, or
+``to_{property}`` and can be implemented explicitly by a translation class, or
 implicitly by defining trivial mappings from a header item to a property, or
 constant mappings that are fixed for all headers independent of any header
 values.
@@ -68,3 +68,5 @@ Python API reference
 .. automodapi:: astro_metadata_translator.bin.translateheader
 
 .. automodapi:: astro_metadata_translator.indexing
+
+.. automodapi:: astro_metadata_translator.file_helpers

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,2 +1,2 @@
-documenteer[pipelines]>=0.6.0,<0.7.0
+documenteer[pipelines]>=0.8.0,<0.9.0
 ltd-conveyor

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,3 +12,46 @@ line_length = 110
 
 [tool.lsst_versions]
 write_to = "python/astro_metadata_translator/version.py"
+
+[tool.pydocstyle]
+convention = "numpy"
+# Our coding style does not require docstrings for magic methods (D105)
+# Our docstyle documents __init__ at the class level (D107)
+# We allow methods to inherit docstrings and this is not compatible with D102.
+# Docstring at the very first line is not required
+# D200, D205 and D400 all complain if the first sentence of the docstring does
+# not fit on one line.
+# D104 - we do not require documentation in __init__.py files.
+add-ignore = ["D107", "D105", "D102", "D104", "D100", "D200", "D205", "D400"]
+
+
+[tool.ruff]
+exclude = [
+    "__init__.py",
+]
+ignore = [
+    "N999",  # Invalid module name
+    "D107",  # Document __init__ at class level.
+    "D105",  # Do not require docstrings on magic methods.
+    "D102",  # Can inherit docstrings.
+    "D100",  # Modules are not required to include documentation.
+    "D205",  # Does not understand if a summary is two lines long.
+]
+line-length = 110
+select = [
+    "E",  # pycodestyle
+    "F",  # pyflakes
+    "N",  # pep8-naming
+    "W",  # pycodestyle
+    "D",  # pydocstyle
+]
+target-version = "py310"
+extend-select = [
+    "RUF100", # Warn about unused noqa
+]
+
+[tool.ruff.pycodestyle]
+max-doc-length = 79
+
+[tool.ruff.pydocstyle]
+convention = "numpy"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,9 @@ line_length = 110
 [tool.lsst_versions]
 write_to = "python/astro_metadata_translator/version.py"
 
+[tool.pytest.ini_options]
+addopts = "--import-mode=importlib"  # Recommended as best practice
+
 [tool.pydocstyle]
 convention = "numpy"
 # Our coding style does not require docstrings for magic methods (D105)

--- a/python/astro_metadata_translator/bin/translateheader.py
+++ b/python/astro_metadata_translator/bin/translateheader.py
@@ -338,8 +338,8 @@ def main() -> int:
     Returns
     -------
     status : `int`
-        Exit status to be passed to `sys.exit()`. 0 if any of the files
-        could be translated. 1 otherwise.
+        Exit status to be passed to `sys.exit`. ``0`` if any of the files
+        could be translated. ``1`` otherwise.
     """
     logging.warn(
         "This command is deprecated. Please use 'astrometadata translate' "

--- a/python/astro_metadata_translator/bin/translateheader.py
+++ b/python/astro_metadata_translator/bin/translateheader.py
@@ -71,7 +71,6 @@ def build_argparser() -> argparse.ArgumentParser:
         The argument parser that defines the ``translate_header.py``
         command-line interface.
     """
-
     parser = argparse.ArgumentParser(description="Summarize headers from astronomical data files")
     parser.add_argument(
         "files",
@@ -342,7 +341,6 @@ def main() -> int:
         Exit status to be passed to `sys.exit()`. 0 if any of the files
         could be translated. 1 otherwise.
     """
-
     logging.warn(
         "This command is deprecated. Please use 'astrometadata translate' "
         " or 'astrometadata dump' instead. See 'astrometadata -h' for more details."

--- a/python/astro_metadata_translator/bin/writesidecar.py
+++ b/python/astro_metadata_translator/bin/writesidecar.py
@@ -76,7 +76,6 @@ def write_sidecar_file(
         `True` if the file was handled successfully, `False` if the file
         could not be processed.
     """
-
     if content_mode not in ("metadata", "translated"):
         raise ValueError(f"Specified content mode '{content_mode}' is not understood.")
 

--- a/python/astro_metadata_translator/cli/astrometadata.py
+++ b/python/astro_metadata_translator/cli/astrometadata.py
@@ -77,6 +77,7 @@ content_option = click.option(
 )
 @click.pass_context
 def main(ctx: click.Context, log_level: int, traceback: bool, packages: Sequence[str]) -> None:
+    """Execute main click command-line."""
     ctx.ensure_object(dict)
 
     logging.basicConfig(level=log_level)
@@ -120,6 +121,7 @@ def main(ctx: click.Context, log_level: int, traceback: bool, packages: Sequence
 def translate(
     ctx: click.Context, files: Sequence[str], quiet: bool, hdrnum: int, mode: str, regex: str
 ) -> None:
+    """Translate a header."""
     # For quiet mode we want to translate everything but report nothing.
     if quiet:
         mode = "none"
@@ -152,6 +154,7 @@ def translate(
 @regex_option
 @click.pass_context
 def dump(ctx: click.Context, files: Sequence[str], hdrnum: int, mode: str, regex: str) -> None:
+    """Dump a header."""
     okay, failed = translate_header(files, regex, hdrnum, ctx.obj["TRACEBACK"], output_mode=mode)
 
     if failed:
@@ -171,6 +174,7 @@ def dump(ctx: click.Context, files: Sequence[str], hdrnum: int, mode: str, regex
 @content_option
 @click.pass_context
 def write_sidecar(ctx: click.Context, files: Sequence[str], hdrnum: int, regex: str, content: str) -> None:
+    """Write a sidecar file with header information."""
     okay, failed = write_sidecar_files(files, regex, hdrnum, content, ctx.obj["TRACEBACK"])
 
     if failed:
@@ -200,6 +204,7 @@ def write_sidecar(ctx: click.Context, files: Sequence[str], hdrnum: int, regex: 
 def write_index(
     ctx: click.Context, files: Sequence[str], hdrnum: int, regex: str, content: str, outpath: str
 ) -> None:
+    """Write a header index file."""
     okay, failed = write_index_files(
         files, regex, hdrnum, ctx.obj["TRACEBACK"], content_mode=content, outpath=outpath
     )

--- a/python/astro_metadata_translator/file_helpers.py
+++ b/python/astro_metadata_translator/file_helpers.py
@@ -71,7 +71,6 @@ except ImportError:
 
     def _read_fits_metadata(file: str, hdu: int, can_raise: bool = False) -> MutableMapping[str, Any] | None:
         """Read a FITS header using astropy."""
-
         # For detailed docstrings see the afw implementation above
         header = None
         try:
@@ -228,7 +227,6 @@ def read_file_info(
         The return value of `ObservationInfo.to_simple()`. Returns `None`
         if there was a problem and `print_trace` is not `None`.
     """
-
     if content_mode not in ("metadata", "translated"):
         raise ValueError(f"Unrecognized content mode request: {content_mode}")
 

--- a/python/astro_metadata_translator/file_helpers.py
+++ b/python/astro_metadata_translator/file_helpers.py
@@ -213,7 +213,7 @@ def read_file_info(
     content_type : `str`, optional
         Form of content to be returned. Can be either ``json`` to return a
         JSON string, ``simple`` to always return a `dict`, or ``native`` to
-        return either a `dict` (for ``metadata``) or `ObservationInfo` for
+        return either a `dict` (for ``metadata``) or `.ObservationInfo` for
         ``translated``.
     outstream : `io.StringIO`, optional
         Output stream to use for standard messages. Defaults to `sys.stdout`.
@@ -223,9 +223,9 @@ def read_file_info(
 
     Returns
     -------
-    simple : `dict` of `str` or `ObservationInfo`
-        The return value of `ObservationInfo.to_simple()`. Returns `None`
-        if there was a problem and `print_trace` is not `None`.
+    simple : `dict` of `str` or `.ObservationInfo`
+        The return value of `.ObservationInfo.to_simple`. Returns `None`
+        if there was a problem and ``print_trace`` is not `None`.
     """
     if content_mode not in ("metadata", "translated"):
         raise ValueError(f"Unrecognized content mode request: {content_mode}")

--- a/python/astro_metadata_translator/file_helpers.py
+++ b/python/astro_metadata_translator/file_helpers.py
@@ -122,7 +122,7 @@ def find_files(files: Iterable[str], regex: str) -> list[str]:
 def read_basic_metadata_from_file(
     file: str, hdrnum: int, errstream: IO = sys.stderr, can_raise: bool = True
 ) -> MutableMapping[str, Any] | None:
-    """Read a raw header from a file, merging if necessary
+    """Read a raw header from a file, merging if necessary.
 
     Parameters
     ----------
@@ -192,7 +192,7 @@ def read_file_info(
     outstream: IO = sys.stdout,
     errstream: IO = sys.stderr,
 ) -> str | MutableMapping[str, Any] | ObservationInfo | None:
-    """Read information from file
+    """Read information from file.
 
     Parameters
     ----------

--- a/python/astro_metadata_translator/headers.py
+++ b/python/astro_metadata_translator/headers.py
@@ -23,13 +23,17 @@ import os
 import posixpath
 from collections import Counter
 from collections.abc import Mapping, MutableMapping, Sequence
-from typing import IO, Any
+from typing import IO, TYPE_CHECKING, Any
 
 import yaml
 from lsst.resources import ResourcePath
 
 from .translator import MetadataTranslator
 from .translators import FitsTranslator
+
+if TYPE_CHECKING:
+    from lsst.resources import ResourceHandleProtocol
+
 
 log = logging.getLogger(__name__)
 
@@ -263,7 +267,7 @@ def merge_headers(
     return merged
 
 
-def _read_yaml(fh: IO[bytes], msg: str) -> Mapping[str, Any] | None:
+def _read_yaml(fh: IO[bytes] | ResourceHandleProtocol, msg: str) -> Mapping[str, Any] | None:
     """Read YAML from file descriptor.
 
     Parameters

--- a/python/astro_metadata_translator/headers.py
+++ b/python/astro_metadata_translator/headers.py
@@ -433,7 +433,6 @@ def fix_header(
 
     The first file located in the search path is used for the correction.
     """
-
     if FIXUP_SENTINEL in header:
         return header[FIXUP_SENTINEL]
 

--- a/python/astro_metadata_translator/indexing.py
+++ b/python/astro_metadata_translator/indexing.py
@@ -295,7 +295,6 @@ def process_index_data(
     -----
     File keys will be relative to the location of the index file.
     """
-
     if COMMON_KEY not in content:
         raise ValueError(f"No '{COMMON_KEY}' key found in dict. Does not look like an index data structure.")
 
@@ -404,7 +403,6 @@ def process_sidecar_data(
         can be overridden using the ``force_metadata`` parameter in which
         case a `dict` will always be returned.
     """
-
     if not isinstance(content, dict):
         raise TypeError(f"Content of sidecar must be a dict, not {type(content)}")
 

--- a/python/astro_metadata_translator/indexing.py
+++ b/python/astro_metadata_translator/indexing.py
@@ -219,7 +219,8 @@ def read_index(
 
     Returns
     -------
-    index_ : `ObservationGroup` or `dict[str, Union[dict, ObservaitonInfo]]`
+    index_ : `.ObservationGroup` or `dict` [ `str`, \
+            `dict` | `.ObservationInfo` ]
         The return content matches that returned by `process_index_data`.
     """
     if not path.endswith(".json"):
@@ -274,22 +275,22 @@ def process_index_data(
     force_metadata : `bool`, optional
         By default the content returned will match the original form that
         was used for the index. If this parameter is `True` an index of
-        `ObservationInfo` will be returned as if it was simple dict content.
+        `.ObservationInfo` will be returned as if it was simple dict content.
     force_dict : `bool`, optional
         If `True` the structure returned will always be a dict keyed
         by filename.
 
     Returns
     -------
-    index : `ObservationGroup` or `dict` of [`str`, `dict`]
-       If the index file referred to `ObservationInfo` this will return
-       an `ObservationGroup`, otherwise a `dict` will be returned with the
+    index : `.ObservationGroup` or `dict` of [`str`, `dict`]
+       If the index file referred to `.ObservationInfo` this will return
+       an `.ObservationGroup`, otherwise a `dict` will be returned with the
        keys being paths to files and the values being the keys and values
        stored in the index (with common information merged in). This
        can be overridden using the ``force_metadata`` parameter. If
        ``force_dict`` is `True` a `dict` will be returned with filename
-       keys even if the index file refers to `ObservationInfo` (the values
-       will be `ObservationInfo` unless ``force_metadata`` is `True`).
+       keys even if the index file refers to `.ObservationInfo` (the values
+       will be `.ObservationInfo` unless ``force_metadata`` is `True`).
 
     Notes
     -----
@@ -343,9 +344,9 @@ def read_sidecar(path: str) -> ObservationInfo | MutableMapping[str, Any]:
 
     Returns
     -------
-    info : `ObservationInfo` or `dict` of [`str`, `dict`]
-        If the sidecar file referred to `ObservationInfo` this will return
-        an `ObservationInfo`, otherwise a `dict` will be returned.
+    info : `.ObservationInfo` or `dict` of [`str`, `dict`]
+        If the sidecar file referred to `.ObservationInfo` this will return
+        an `.ObservationInfo`, otherwise a `dict` will be returned.
     """
     if not path.endswith(".json"):
         raise ValueError(f"Sidecar files must be in .json format; got {path}")
@@ -393,13 +394,13 @@ def process_sidecar_data(
     force_metadata : `bool`, optional
         By default the content returned will match the original form that
         was used for the sidecar. If this parameter is `True` a sidecar of
-        `ObservationInfo` will be returned as if it was simple dict content.
+        `.ObservationInfo` will be returned as if it was simple dict content.
 
     Returns
     -------
-    info : `ObservationInfo` or `dict` of [`str`, `Any`]
-        If the sidecar file referred to `ObservationInfo` this will return
-        an `ObservationInfo`, otherwise a `dict` will be returned. This
+    info : `.ObservationInfo` or `dict` of [`str`, `~typing.Any`]
+        If the sidecar file referred to `.ObservationInfo` this will return
+        an `.ObservationInfo`, otherwise a `dict` will be returned. This
         can be overridden using the ``force_metadata`` parameter in which
         case a `dict` will always be returned.
     """

--- a/python/astro_metadata_translator/indexing.py
+++ b/python/astro_metadata_translator/indexing.py
@@ -9,6 +9,8 @@
 # Use of this source code is governed by a 3-clause BSD-style
 # license that can be found in the LICENSE file.
 
+"""Functions to support file indexing."""
+
 from __future__ import annotations
 
 __all__ = (
@@ -19,8 +21,6 @@ __all__ = (
     "process_index_data",
     "process_sidecar_data",
 )
-
-"""Functions to support file indexing."""
 
 import collections.abc
 import json

--- a/python/astro_metadata_translator/observationGroup.py
+++ b/python/astro_metadata_translator/observationGroup.py
@@ -9,9 +9,9 @@
 # Use of this source code is governed by a 3-clause BSD-style
 # license that can be found in the LICENSE file.
 
-from __future__ import annotations
+"""Represent a collection of translated headers."""
 
-"""Represent a collection of translated headers"""
+from __future__ import annotations
 
 __all__ = ("ObservationGroup",)
 
@@ -123,7 +123,10 @@ class ObservationGroup(MutableSequence):
         return iter(self._members)
 
     def __eq__(self, other: Any) -> bool:
-        """Compares equal if all the members are equal in the same order."""
+        """Check equality with another group.
+
+        Compare equal if all the members are equal in the same order.
+        """
         if not isinstance(other, ObservationGroup):
             return NotImplemented
 
@@ -223,7 +226,7 @@ class ObservationGroup(MutableSequence):
 
     @classmethod
     def from_simple(cls, simple: list[dict[str, Any]]) -> ObservationGroup:
-        """Convert simplified form back to `ObservationGroup`
+        """Convert simplified form back to `ObservationGroup`.
 
         Parameters
         ----------

--- a/python/astro_metadata_translator/observationInfo.py
+++ b/python/astro_metadata_translator/observationInfo.py
@@ -487,7 +487,7 @@ class ObservationInfo:
 
         Returns
         -------
-        simple : `dict` of [`str`, `Any`]
+        simple : `dict` of [`str`, `~typing.Any`]
             Simple dict of all properties.
 
         Notes
@@ -542,7 +542,7 @@ class ObservationInfo:
 
         Parameters
         ----------
-        simple : `dict` [`str`, `Any`]
+        simple : `dict` [`str`, `~typing.Any`]
             The dict returned by `to_simple()`
 
         Returns

--- a/python/astro_metadata_translator/observationInfo.py
+++ b/python/astro_metadata_translator/observationInfo.py
@@ -9,7 +9,7 @@
 # Use of this source code is governed by a 3-clause BSD-style
 # license that can be found in the LICENSE file.
 
-"""Represent standard metadata from instrument headers"""
+"""Represent standard metadata from instrument headers."""
 
 from __future__ import annotations
 
@@ -252,7 +252,7 @@ class ObservationInfo:
     def _get_all_properties(
         extensions: dict[str, PropertyDefinition] | None = None
     ) -> dict[str, PropertyDefinition]:
-        """Return the definitions of all properties
+        """Return the definitions of all properties.
 
         Parameters
         ----------
@@ -272,7 +272,7 @@ class ObservationInfo:
         return properties
 
     def _declare_extensions(self, extensions: dict[str, PropertyDefinition] | None) -> None:
-        """Declare and set up extension properties
+        """Declare and set up extension properties.
 
         This should always be called internally as part of the creation of a
         new `ObservationInfo`.
@@ -305,7 +305,7 @@ class ObservationInfo:
         self.all_properties = self._get_all_properties(extensions)
 
     def __setattr__(self, name: str, value: Any) -> Any:
-        """Set attribute
+        """Set attribute.
 
         This provides read-only protection for the extension properties. The
         core set of properties have read-only protection via the use of the
@@ -397,7 +397,10 @@ class ObservationInfo:
         return result
 
     def __eq__(self, other: Any) -> bool:
-        """Compares equal if standard properties are equal"""
+        """Check equality with another object.
+
+        Compares equal if standard properties are equal.
+        """
         if not isinstance(other, ObservationInfo):
             return NotImplemented
 
@@ -431,7 +434,7 @@ class ObservationInfo:
         return self.datetime_begin > other.datetime_begin
 
     def __getstate__(self) -> tuple[Any, ...]:
-        """Get pickleable state
+        """Get pickleable state.
 
         Returns the properties.  Deliberately does not preserve the full
         current state; in particular, does not return the full header or
@@ -449,7 +452,7 @@ class ObservationInfo:
         return state, self.extensions
 
     def __setstate__(self, state: tuple[Any, ...]) -> None:
-        """Set object state from pickle
+        """Set object state from pickle.
 
         Parameters
         ----------

--- a/python/astro_metadata_translator/observationInfo.py
+++ b/python/astro_metadata_translator/observationInfo.py
@@ -631,7 +631,6 @@ class ObservationInfo:
             Raised if a supplied value does not match the expected type
             of the property.
         """
-
         obsinfo = cls(None)
         obsinfo._declare_extensions(extensions)
 

--- a/python/astro_metadata_translator/properties.py
+++ b/python/astro_metadata_translator/properties.py
@@ -80,7 +80,7 @@ def datetime_to_simple(datetime: astropy.time.Time) -> tuple[float, float]:
 
 
 def simple_to_datetime(simple: tuple[float, float], **kwargs: Any) -> astropy.time.Time:
-    """Convert simple form back to astropy.time.Time"""
+    """Convert simple form back to astropy.time.Time."""
     return astropy.time.Time(*simple, format="jd", scale="tai")
 
 
@@ -135,7 +135,7 @@ def simple_to_pressure(simple: float, **kwargs: Any) -> astropy.units.Quantity:
 
 
 def skycoord_to_simple(skycoord: astropy.coordinates.SkyCoord) -> tuple[float, float]:
-    """Convert SkyCoord to ICRS RA/Dec tuple"""
+    """Convert SkyCoord to ICRS RA/Dec tuple."""
     icrs = skycoord.icrs
     return (icrs.ra.to_value(astropy.units.deg), icrs.dec.to_value(astropy.units.deg))
 

--- a/python/astro_metadata_translator/serialize/fits.py
+++ b/python/astro_metadata_translator/serialize/fits.py
@@ -76,7 +76,6 @@ def info_to_fits(obs_info: ObservationInfo) -> tuple[dict[str, Any], dict[str, s
         Suitable comment string.  There will be at most one entry for each key
         in ``cards``.
     """
-
     cards = {}
     comments = {}
 
@@ -107,7 +106,6 @@ def group_to_fits(obs_group: ObservationGroup) -> tuple[dict[str, Any], dict[str
         Suitable comment string.  There will be at most one entry for each key
         in ``cards``.
     """
-
     cards = {}
     comments = {}
 

--- a/python/astro_metadata_translator/tests.py
+++ b/python/astro_metadata_translator/tests.py
@@ -65,7 +65,7 @@ if daf_base is None:
 
 
 def read_test_file(filename: str, dir: str | None = None) -> MutableMapping[str, Any]:
-    """Read the named test file relative to the location of this helper
+    """Read the named test file relative to the location of this helper.
 
     Parameters
     ----------

--- a/python/astro_metadata_translator/translator.py
+++ b/python/astro_metadata_translator/translator.py
@@ -675,7 +675,7 @@ class MetadataTranslator:
 
     @property
     def _log_prefix(self) -> str:
-        """Standard prefix that can be used for log messages to report
+        """Return standard prefix that can be used for log messages to report
         useful context.
 
         Will be either the filename and obsid, or just the obsid depending

--- a/python/astro_metadata_translator/translator.py
+++ b/python/astro_metadata_translator/translator.py
@@ -48,7 +48,7 @@ def cache_translation(func: Callable, method: str | None = None) -> Callable:
 
     Parameters
     ----------
-    func : `function`
+    func : `~collections.abc.Callable`
         Translation method to cache.
     method : `str`, optional
         Name of the translation method to cache.  Not needed if the decorator
@@ -57,7 +57,7 @@ def cache_translation(func: Callable, method: str | None = None) -> Callable:
 
     Returns
     -------
-    wrapped : `function`
+    wrapped : `~collections.abc.Callable`
         Method wrapped by the caching function.
 
     Notes
@@ -197,7 +197,7 @@ class MetadataTranslator:
         Retrieves the attribute associated with the given name.
         Then looks in all the parent classes to determine whether that
         attribute comes from a parent class or from the current class.
-        Attributes are compared using `id()`.
+        Attributes are compared using :py:func:`id`.
         """
         # The attribute to compare.
         if not hasattr(cls, name):
@@ -232,7 +232,7 @@ class MetadataTranslator:
 
         Returns
         -------
-        f : `function`
+        f : `~collections.abc.Callable`
             Function returning the constant.
         """
 
@@ -246,11 +246,16 @@ class MetadataTranslator:
             return_type = type(constant)
             property_doc = f"Returns constant value for '{property_key}' property"
 
+        if return_type.__module__ == "builtins":
+            full_name = return_type.__name__
+        else:
+            full_name = f"{return_type.__module__}.{return_type.__qualname__}"
+
         constant_translator.__doc__ = f"""{property_doc}
 
         Returns
         -------
-        translation : `{return_type}`
+        translation : `{full_name}`
             Translated property.
         """
         return constant_translator
@@ -294,7 +299,7 @@ class MetadataTranslator:
         unit : `astropy.units.Unit`, optional
             If not `None`, the value read from the header will be converted
             to a `~astropy.units.Quantity`.  Only supported for numeric values.
-        checker : `function`, optional
+        checker : `~collections.abc.Callable`, optional
             Callback function to be used by the translator method in case the
             keyword is not present.  Function will be executed as if it is
             a method of the translator class.  Running without raising an
@@ -303,7 +308,7 @@ class MetadataTranslator:
 
         Returns
         -------
-        t : `function`
+        t : `~collections.abc.Callable`
             Function implementing a translator with the specified
             parameters.
         """
@@ -389,7 +394,7 @@ class MetadataTranslator:
         ``_trivialMap`` can be defined.  Trivial mappings are a dict mapping a
         generic property to either a header keyword, or a tuple consisting of
         the header keyword and a dict containing key value pairs suitable for
-        the `MetadataTranslator.quantity_from_card()` method.
+        the `MetadataTranslator.quantity_from_card` method.
         """
         super().__init_subclass__(**kwargs)
 
@@ -871,7 +876,7 @@ class MetadataTranslator:
         maximum : `float`, optional
             Maximum possible valid value, optional.  If the calculated value
             is above this value, the default value will be used.
-        checker : `function`, optional
+        checker : `~collections.abc.Callable`, optional
             Callback function to be used by the translator method in case the
             keyword is not present.  Function will be executed as if it is
             a method of the translator class.  Running without raising an
@@ -1132,13 +1137,13 @@ class MetadataTranslator:
         In the base class implementation it is assumed that
         this supplied header is the only useful header for metadata translation
         and it will be returned unchanged if given. This can avoid
-        unnecesarily re-opening the file and re-reading the header when the
+        unnecessarily re-opening the file and re-reading the header when the
         content is already known.
 
         If no header is supplied, a header will be read from the supplied
-        file using `read_basic_metadata_from_file`, allowing it to merge
-        the primary and secondary header of a multi-extension FITS file.
-        Subclasses can read the header from the data file using whatever
+        file using `~.file_helpers.read_basic_metadata_from_file`, allowing it
+        to merge the primary and secondary header of a multi-extension FITS
+        file. Subclasses can read the header from the data file using whatever
         technique is best for that instrument.
 
         Subclasses can return multiple headers and ignore the externally
@@ -1201,12 +1206,12 @@ def _make_abstract_translator_method(
         Description of the property.
     return_typedoc : `str`
         Type string of this property (used in the doc string).
-    return_type : `class`
+    return_type : `type`
         Type of this property.
 
     Returns
     -------
-    m : `function`
+    m : `~collections.abc.Callable`
         Translator method for this property.
     """
 
@@ -1276,7 +1281,7 @@ def _make_forwarded_stub_translator_method(
 
     Parameters
     ----------
-    cls : `class`
+    cls : `type`
         Class to use when referencing `super()`.  This would usually be
         `StubTranslator`.
     property : `str`
@@ -1285,12 +1290,12 @@ def _make_forwarded_stub_translator_method(
         Description of the property.
     return_typedoc : `str`
         Type string of this property (used in the doc string).
-    return_type : `class`
+    return_type : `type`
         Type of this property.
 
     Returns
     -------
-    m : `function`
+    m : `~collections.abc.Callable`
         Stub translator method for this property.
     """
     method = f"to_{property}"

--- a/python/astro_metadata_translator/translator.py
+++ b/python/astro_metadata_translator/translator.py
@@ -9,7 +9,7 @@
 # Use of this source code is governed by a 3-clause BSD-style
 # license that can be found in the LICENSE file.
 
-"""Classes and support code for metadata translation"""
+"""Classes and support code for metadata translation."""
 
 from __future__ import annotations
 
@@ -44,10 +44,7 @@ _VERSION_CACHE: dict[type, str] = dict()
 
 
 def cache_translation(func: Callable, method: str | None = None) -> Callable:
-    """Decorator to cache the result of a translation method.
-
-    Especially useful when a translation uses many other translation
-    methods.  Should be used only on ``to_x()`` methods.
+    """Cache the result of a translation method.
 
     Parameters
     ----------
@@ -62,6 +59,18 @@ def cache_translation(func: Callable, method: str | None = None) -> Callable:
     -------
     wrapped : `function`
         Method wrapped by the caching function.
+
+    Notes
+    -----
+    Especially useful when a translation uses many other translation
+    methods or involves significant computation.
+    Should be used only on ``to_x()`` methods.
+
+    .. code-block:: python
+
+        @cache_translation
+        def to_detector_num(self):
+            ....
     """
     name = func.__name__ if method is None else method
 
@@ -76,7 +85,7 @@ def cache_translation(func: Callable, method: str | None = None) -> Callable:
 
 
 class MetadataTranslator:
-    """Per-instrument metadata translation support
+    """Per-instrument metadata translation support.
 
     Parameters
     ----------
@@ -486,7 +495,7 @@ class MetadataTranslator:
     def can_translate_with_options(
         cls, header: Mapping[str, Any], options: dict[str, Any], filename: str | None = None
     ) -> bool:
-        """Helper method for `can_translate` allowing options.
+        """Determine if a header can be translated with different criteria.
 
         Parameters
         ----------
@@ -522,7 +531,7 @@ class MetadataTranslator:
     def determine_translator(
         cls, header: Mapping[str, Any], filename: str | None = None
     ) -> type[MetadataTranslator]:
-        """Determine a translation class by examining the header
+        """Determine a translation class by examining the header.
 
         Parameters
         ----------
@@ -707,7 +716,7 @@ class MetadataTranslator:
     def validate_value(
         value: float, default: float, minimum: float | None = None, maximum: float | None = None
     ) -> float:
-        """Validate the supplied value, returning a new value if out of range
+        """Validate the supplied value, returning a new value if out of range.
 
         Parameters
         ----------
@@ -768,8 +777,8 @@ class MetadataTranslator:
         return True
 
     def resource_root(self) -> tuple[str | None, str | None]:
-        """Package resource to use to locate correction resources within an
-        installed package.
+        """Return package resource to use to locate correction resources within
+        an installed package.
 
         Returns
         -------
@@ -817,7 +826,7 @@ class MetadataTranslator:
         return self.is_keyword_defined(self._header, keyword)
 
     def are_keys_ok(self, keywords: Iterable[str]) -> bool:
-        """Are the supplied keys all present and defined?
+        """Are the supplied keys all present and defined?.
 
         Parameters
         ----------

--- a/python/astro_metadata_translator/translators/decam.py
+++ b/python/astro_metadata_translator/translators/decam.py
@@ -9,7 +9,7 @@
 # Use of this source code is governed by a 3-clause BSD-style
 # license that can be found in the LICENSE file.
 
-"""Metadata translation code for DECam FITS headers"""
+"""Metadata translation code for DECam FITS headers."""
 
 from __future__ import annotations
 

--- a/python/astro_metadata_translator/translators/decam.py
+++ b/python/astro_metadata_translator/translators/decam.py
@@ -254,7 +254,6 @@ class DecamTranslator(FitsTranslator):
         location : `astropy.coordinates.EarthLocation`
             An object representing the location of the telescope.
         """
-
         if self.is_key_ok("OBS-LONG"):
             # OBS-LONG has west-positive sign so must be flipped
             lon = self._header["OBS-LONG"] * -1.0

--- a/python/astro_metadata_translator/translators/fits.py
+++ b/python/astro_metadata_translator/translators/fits.py
@@ -9,7 +9,7 @@
 # Use of this source code is governed by a 3-clause BSD-style
 # license that can be found in the LICENSE file.
 
-"""Metadata translation code for standard FITS headers"""
+"""Metadata translation code for standard FITS headers."""
 
 from __future__ import annotations
 
@@ -79,7 +79,7 @@ class FitsTranslator(MetadataTranslator):
 
     @classmethod
     def _from_fits_date_string(cls, date_str: str, scale: str = "utc", time_str: str | None = None) -> Time:
-        """Parse standard FITS ISO-style date string and return time object
+        """Parse standard FITS ISO-style date string and return time object.
 
         Parameters
         ----------
@@ -107,7 +107,7 @@ class FitsTranslator(MetadataTranslator):
     def _from_fits_date(
         self, date_key: str, mjd_key: str | None = None, scale: str | None = None
     ) -> Time | None:
-        """Calculate a date object from the named FITS header
+        """Calculate a date object from the named FITS header.
 
         Uses the TIMESYS header if present to determine the time scale,
         defaulting to UTC.  Can be overridden since sometimes headers

--- a/python/astro_metadata_translator/translators/helpers.py
+++ b/python/astro_metadata_translator/translators/helpers.py
@@ -71,7 +71,7 @@ def is_non_science(self: MetadataTranslator) -> None:
 
 
 def altitude_from_zenith_distance(zd: astropy.units.Quantity) -> astropy.units.Quantity:
-    """Convert zenith distance to altitude
+    """Convert zenith distance to altitude.
 
     Parameters
     ----------

--- a/python/astro_metadata_translator/translators/hsc.py
+++ b/python/astro_metadata_translator/translators/hsc.py
@@ -9,7 +9,7 @@
 # Use of this source code is governed by a 3-clause BSD-style
 # license that can be found in the LICENSE file.
 
-"""Metadata translation code for HSC FITS headers"""
+"""Metadata translation code for HSC FITS headers."""
 
 from __future__ import annotations
 
@@ -211,7 +211,7 @@ class HscTranslator(SuprimeCamTranslator):
 
     @cache_translation
     def to_exposure_id(self) -> int:
-        """Calculate unique exposure integer for this observation
+        """Calculate unique exposure integer for this observation.
 
         Returns
         -------

--- a/python/astro_metadata_translator/translators/hsc.py
+++ b/python/astro_metadata_translator/translators/hsc.py
@@ -264,7 +264,6 @@ class HscTranslator(SuprimeCamTranslator):
         num : `int`
             Detector number.
         """
-
         ccd = super().to_detector_num()
         try:
             tjd = self._get_adjusted_mjd()

--- a/python/astro_metadata_translator/translators/megaprime.py
+++ b/python/astro_metadata_translator/translators/megaprime.py
@@ -9,7 +9,7 @@
 # Use of this source code is governed by a 3-clause BSD-style
 # license that can be found in the LICENSE file.
 
-"""Metadata translation code for CFHT MegaPrime FITS headers"""
+"""Metadata translation code for CFHT MegaPrime FITS headers."""
 
 from __future__ import annotations
 

--- a/python/astro_metadata_translator/translators/sdss.py
+++ b/python/astro_metadata_translator/translators/sdss.py
@@ -183,7 +183,6 @@ class SdssTranslator(FitsTranslator):
         location : `astropy.coordinates.EarthLocation`
             An object representing the location of the telescope.
         """
-
         # Look up the value since files do not have location
         value = EarthLocation.of_site("apo")
 

--- a/python/astro_metadata_translator/translators/sdss.py
+++ b/python/astro_metadata_translator/translators/sdss.py
@@ -9,7 +9,7 @@
 # Use of this source code is governed by a 3-clause BSD-style
 # license that can be found in the LICENSE file.
 
-"""Metadata translation code for SDSS FITS headers"""
+"""Metadata translation code for SDSS FITS headers."""
 
 from __future__ import annotations
 

--- a/python/astro_metadata_translator/translators/subaru.py
+++ b/python/astro_metadata_translator/translators/subaru.py
@@ -9,7 +9,7 @@
 # Use of this source code is governed by a 3-clause BSD-style
 # license that can be found in the LICENSE file.
 
-"""Metadata translation code for Subaru telescope"""
+"""Metadata translation code for Subaru telescope."""
 
 from __future__ import annotations
 
@@ -26,7 +26,7 @@ class SubaruTranslator(FitsTranslator):
 
     @cache_translation
     def to_location(self) -> EarthLocation:
-        """Returns the location of the Subaru telescope on Mauna Kea.
+        """Return the location of the Subaru telescope on Mauna Kea.
 
         Hardcodes the location and does not look at any headers.
 

--- a/python/astro_metadata_translator/translators/suprimecam.py
+++ b/python/astro_metadata_translator/translators/suprimecam.py
@@ -9,7 +9,7 @@
 # Use of this source code is governed by a 3-clause BSD-style
 # license that can be found in the LICENSE file.
 
-"""Metadata translation code for SuprimeCam FITS headers"""
+"""Metadata translation code for SuprimeCam FITS headers."""
 
 from __future__ import annotations
 
@@ -96,7 +96,7 @@ class SuprimeCamTranslator(SubaruTranslator):
         return False
 
     def _get_adjusted_mjd(self) -> int:
-        """Calculate the modified julian date offset from reference day
+        """Calculate the modified julian date offset from reference day.
 
         Returns
         -------
@@ -150,7 +150,7 @@ class SuprimeCamTranslator(SubaruTranslator):
 
     @cache_translation
     def to_exposure_id(self) -> int:
-        """Calculate unique exposure integer for this observation
+        """Calculate unique exposure integer for this observation.
 
         Returns
         -------

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 astropy >=3.0.5
 pyyaml >=3.13
-lsst-resources

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 astropy >=3.0.5
 pyyaml >=3.13
+lsst-resources

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 astropy >=3.0.5
 pyyaml >=3.13
+click >=8

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,7 +33,6 @@ install_requires =
 tests_require =
   pytest >= 3.2
   flake8 >= 3.7.5
-  pytest-flake8 >= 1.0.4
 
 [options.packages.find]
 where=python
@@ -51,7 +50,3 @@ max-line-length = 110
 max-doc-length = 79
 ignore = W503, E203
 exclude = __init__.py version.py
-
-[tool:pytest]
-addopts = --flake8
-flake8-ignore = W503 E203

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,7 +30,6 @@ setup_requires =
 install_requires =
   astropy >=3.0.5
   pyyaml >=3.13
-  lsst-resources
 tests_require =
   pytest >= 3.2
   flake8 >= 3.7.5

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,6 +30,7 @@ setup_requires =
 install_requires =
   astropy >=3.0.5
   pyyaml >=3.13
+  lsst-resources
 tests_require =
   pytest >= 3.2
   flake8 >= 3.7.5

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,6 +30,7 @@ setup_requires =
 install_requires =
   astropy >=3.0.5
   pyyaml >=3.13
+  click >= 8
 tests_require =
   pytest >= 3.2
   flake8 >= 3.7.5

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,9 +10,9 @@ classifiers =
     License :: OSI Approved :: BSD License
     Operating System :: OS Independent
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
     Topic :: Scientific/Engineering :: Astronomy
 long_description = file: README.md
 long_description_content_type = text/markdown

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -41,7 +41,6 @@ class BasicTestCase(unittest.TestCase):
 
     def test_simple(self):
         """Test that we can simplify an ObservationInfo."""
-
         reference = dict(
             boresight_airmass=1.5,
             focus_z=1.0 * u.mm,

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -19,6 +19,8 @@ from astro_metadata_translator import ObservationInfo, makeObservationInfo
 
 
 class BasicTestCase(unittest.TestCase):
+    """Test basic metadata translation functionality."""
+
     def test_basic(self):
         version = astro_metadata_translator.__version__
         self.assertIsNotNone(version)

--- a/tests/test_cfht.py
+++ b/tests/test_cfht.py
@@ -21,6 +21,8 @@ TESTDIR = os.path.abspath(os.path.dirname(__file__))
 
 
 class MegaPrimeTestCase(unittest.TestCase, MetadataAssertHelper):
+    """Test CFHT Megaprime translations."""
+
     datadir = os.path.join(TESTDIR, "data")
 
     def test_megaprime_translator(self):

--- a/tests/test_decam.py
+++ b/tests/test_decam.py
@@ -20,6 +20,8 @@ TESTDIR = os.path.abspath(os.path.dirname(__file__))
 
 
 class DecamTestCase(unittest.TestCase, MetadataAssertHelper):
+    """Test DECam translations."""
+
     datadir = os.path.join(TESTDIR, "data")
 
     def test_decam_translator(self):

--- a/tests/test_extensions.py
+++ b/tests/test_extensions.py
@@ -21,6 +21,8 @@ NUMBER = 12345
 
 
 class DummyTranslator(StubTranslator):
+    """Test translation class that supports extensions."""
+
     name = "dummy"
     supported_instrument = "dummy"
     extensions = dict(
@@ -36,11 +38,13 @@ class DummyTranslator(StubTranslator):
         return "INSTRUME" in header and header["INSTRUME"] == "dummy"
 
     def to_ext_number(self):
-        """Return the combination on my luggage"""
+        """Return the combination on my luggage."""
         return NUMBER
 
 
 class ExtensionsTestCase(unittest.TestCase):
+    """Test support for extended properties."""
+
     def setUp(self):
         self.header = dict(INSTRUME="dummy")
         # The test translator is incomplete so it will issue warnings
@@ -49,13 +53,13 @@ class ExtensionsTestCase(unittest.TestCase):
             self.obsinfo = ObservationInfo(self.header)
 
     def assert_observation_info(self, obsinfo):
-        """Check that the `ObservationInfo` is as expected"""
+        """Check that the `ObservationInfo` is as expected."""
         self.assertIsInstance(obsinfo, ObservationInfo)
         self.assertEqual(obsinfo.ext_foo, FOO)
         self.assertEqual(obsinfo.ext_number, NUMBER)
 
     def test_basic(self):
-        """Test construction of extended ObservationInfo"""
+        """Test construction of extended ObservationInfo."""
         # Behaves like the original
         self.assert_observation_info(self.obsinfo)
 
@@ -75,12 +79,12 @@ class ExtensionsTestCase(unittest.TestCase):
             makeObservationInfo(extensions=DummyTranslator.extensions, ext_foo=98765)
 
     def test_pickle(self):
-        """Test that pickling works on ObservationInfo with extensions"""
+        """Test that pickling works on ObservationInfo with extensions."""
         obsinfo = pickle.loads(pickle.dumps(self.obsinfo))
         self.assert_observation_info(obsinfo)
 
     def test_simple(self):
-        """Test that simple representation works"""
+        """Test that simple representation works."""
         simple = self.obsinfo.to_simple()
         self.assertIn("ext_foo", simple)
         self.assertIn("ext_number", simple)
@@ -88,7 +92,7 @@ class ExtensionsTestCase(unittest.TestCase):
         self.assert_observation_info(obsinfo)
 
     def test_json(self):
-        """Test that JSON representation works"""
+        """Test that JSON representation works."""
         json = self.obsinfo.to_json()
         self.assertIn("ext_foo", json)
         self.assertIn("ext_number", json)

--- a/tests/test_groups.py
+++ b/tests/test_groups.py
@@ -20,6 +20,8 @@ TESTDIR = os.path.abspath(os.path.dirname(__file__))
 
 
 class ObservationGroupTestCase(unittest.TestCase):
+    """Test grouping of observations."""
+
     datadir = os.path.join(TESTDIR, "data")
 
     def setUp(self):

--- a/tests/test_headers.py
+++ b/tests/test_headers.py
@@ -37,7 +37,8 @@ class NotDecamTranslator(DecamTranslator):
 
 class NotDecamTranslator2(NotDecamTranslator):
     """This is like NotDecamTranslator but has a fixup that will break on
-    repeat."""
+    repeat.
+    """
 
     name = None
 
@@ -49,7 +50,8 @@ class NotDecamTranslator2(NotDecamTranslator):
 
 class AlsoNotDecamTranslator(DecamTranslator):
     """This is a DECam translator with override list of header corrections
-    that fails."""
+    that fails.
+    """
 
     name = None
 
@@ -386,7 +388,6 @@ class HeadersTestCase(unittest.TestCase):
 class FixHeadersTestCase(unittest.TestCase):
     def test_basic_fix_header(self):
         """Test that a header can be fixed if we specify a local path."""
-
         header = read_test_file("fitsheader-decam-0160496.yaml", dir=os.path.join(TESTDIR, "data"))
         self.assertEqual(header["DETECTOR"], "S3-111_107419-8-3")
 
@@ -421,7 +422,8 @@ class FixHeadersTestCase(unittest.TestCase):
 
     def test_hsc_fix_header(self):
         """Check that one of the known HSC corrections is being applied
-        properly."""
+        properly.
+        """
         header = {"EXP-ID": "HSCA00120800", "INSTRUME": "HSC", "DATA-TYP": "FLAT"}
 
         fixed = fix_header(header, translator_class=HscTranslator)
@@ -440,8 +442,8 @@ class FixHeadersTestCase(unittest.TestCase):
 
     def test_decam_fix_header(self):
         """Check that one of the known DECam corrections is being applied
-        properly."""
-
+        properly.
+        """
         # This header is a bias (zero) with an erroneous Y filter
         header = read_test_file("fitsheader-decam-0160496.yaml", dir=os.path.join(TESTDIR, "data"))
         fixed = fix_header(header, translator_class=DecamTranslator)
@@ -450,7 +452,6 @@ class FixHeadersTestCase(unittest.TestCase):
 
     def test_translator_fix_header(self):
         """Check that translator classes can fix headers."""
-
         # Read in a known header
         header = read_test_file("fitsheader-decam-0160496.yaml", dir=os.path.join(TESTDIR, "data"))
         self.assertEqual(header["DTSITE"], "ct")
@@ -469,7 +470,6 @@ class FixHeadersTestCase(unittest.TestCase):
 
     def test_no_double_fix(self):
         """Check that header fixup only happens once."""
-
         # Read in a known header
         header = read_test_file("fitsheader-decam-0160496.yaml", dir=os.path.join(TESTDIR, "data"))
         self.assertEqual(header["DTSITE"], "ct")

--- a/tests/test_headers.py
+++ b/tests/test_headers.py
@@ -20,7 +20,7 @@ TESTDIR = os.path.abspath(os.path.dirname(__file__))
 
 
 class NotDecamTranslator(DecamTranslator):
-    """This is a DECam translator with override list of header corrections."""
+    """A DECam translator with override list of header corrections."""
 
     name = None
 
@@ -36,7 +36,7 @@ class NotDecamTranslator(DecamTranslator):
 
 
 class NotDecamTranslator2(NotDecamTranslator):
-    """This is like NotDecamTranslator but has a fixup that will break on
+    """Similar to NotDecamTranslator but has a fixup that will break on
     repeat.
     """
 
@@ -49,7 +49,7 @@ class NotDecamTranslator2(NotDecamTranslator):
 
 
 class AlsoNotDecamTranslator(DecamTranslator):
-    """This is a DECam translator with override list of header corrections
+    """A DECam translator with override list of header corrections
     that fails.
     """
 
@@ -61,7 +61,7 @@ class AlsoNotDecamTranslator(DecamTranslator):
 
 
 class NullDecamTranslator(DecamTranslator):
-    """This is a DECam translator that doesn't do any fixes."""
+    """A DECam translator that doesn't do any fixes."""
 
     name = None
 
@@ -71,6 +71,8 @@ class NullDecamTranslator(DecamTranslator):
 
 
 class HeadersTestCase(unittest.TestCase):
+    """Test header manipulation utilities."""
+
     def setUp(self):
         # Define reference headers
         self.h1 = dict(
@@ -386,6 +388,8 @@ class HeadersTestCase(unittest.TestCase):
 
 
 class FixHeadersTestCase(unittest.TestCase):
+    """Test header fix up."""
+
     def test_basic_fix_header(self):
         """Test that a header can be fixed if we specify a local path."""
         header = read_test_file("fitsheader-decam-0160496.yaml", dir=os.path.join(TESTDIR, "data"))

--- a/tests/test_indexing.py
+++ b/tests/test_indexing.py
@@ -84,7 +84,6 @@ class IndexingTestCase(unittest.TestCase):
 
     def test_file_reading(self):
         """Test the low-level file reader"""
-
         # First with a real header (but YAML)
         file = os.path.join(TESTDATA, "fitsheader-hsc-HSCA04090107.yaml")
         info = read_file_info(file, 1, None, "metadata", content_type="simple")
@@ -188,7 +187,6 @@ class IndexingTestCase(unittest.TestCase):
 
     def test_obs_info_sidecar(self):
         """Test reading of older files with missing content."""
-
         # First with a real header (but YAML)
         file = os.path.join(TESTDATA, "fitsheader-hsc.yaml")
         info = read_file_info(file, 1, None, "translated", content_type="native")

--- a/tests/test_indexing.py
+++ b/tests/test_indexing.py
@@ -30,8 +30,10 @@ TESTDATA = os.path.join(TESTDIR, "data")
 
 
 class IndexingTestCase(unittest.TestCase):
+    """Test indexing and sidecar functionality."""
+
     def test_indexing(self):
-        """Test that we can index two headers"""
+        """Test that we can index two headers."""
         files = ["fitsheader-hsc-HSCA04090107.yaml", "fitsheader-hsc.yaml"]
         files = [os.path.join(TESTDATA, f) for f in files]
 
@@ -83,7 +85,7 @@ class IndexingTestCase(unittest.TestCase):
         self.assertEqual(metadata[files[1]]["TELESCOP"], index["__COMMON__"]["TELESCOP"])
 
     def test_file_reading(self):
-        """Test the low-level file reader"""
+        """Test the low-level file reader."""
         # First with a real header (but YAML)
         file = os.path.join(TESTDATA, "fitsheader-hsc-HSCA04090107.yaml")
         info = read_file_info(file, 1, None, "metadata", content_type="simple")

--- a/tests/test_sdss.py
+++ b/tests/test_sdss.py
@@ -20,6 +20,8 @@ TESTDIR = os.path.abspath(os.path.dirname(__file__))
 
 
 class SdssTestCase(unittest.TestCase, MetadataAssertHelper):
+    """Test SDSS translations."""
+
     datadir = os.path.join(TESTDIR, "data")
 
     def test_sdss_translator(self):

--- a/tests/test_shadowing.py
+++ b/tests/test_shadowing.py
@@ -15,27 +15,43 @@ from astro_metadata_translator import StubTranslator
 
 
 class ShadowBase(StubTranslator):
+    """Base class for testing shadowing."""
+
     def to_instrument(self):
         return "BaseInstrument"
 
 
 class ConstTranslator(StubTranslator):
+    """Simple translation class with a constant mapping."""
+
     _const_map = {"instrument": "InstrumentB"}
 
 
 class TrivialTranslator(ConstTranslator):
-    # This should not pick up the _const_map from parent class
+    """Translator inheriting from the constant mapping class but with an
+    override.
+
+    This class should not pick up the _const_map from parent class.
+    """
+
     _trivial_map = {"instrument": "INSTRUME"}
 
 
 class ExplicitTranslator(TrivialTranslator):
-    # The explicit method should override the parent implementations
-    # and not inherit the _trivial_map from parent.
+    """Translation class with explicit method inheriting from class
+    with automatic translation methods.
+
+    The explicit method should override the parent implementations
+    and not inherit the _trivial_map from parent.
+    """
+
     def to_instrument(self):
         return "InstrumentE"
 
 
 class TranslatorShadowing(unittest.TestCase):
+    """Test that shadowed translations are detected."""
+
     def test_shadowing(self):
         with self.assertLogs("astro_metadata_translator", level="WARN") as cm:
 

--- a/tests/test_subaru.py
+++ b/tests/test_subaru.py
@@ -21,6 +21,8 @@ TESTDIR = os.path.abspath(os.path.dirname(__file__))
 
 
 class HscTestCase(unittest.TestCase, MetadataAssertHelper):
+    """Test HSC translations."""
+
     datadir = os.path.join(TESTDIR, "data")
 
     def test_hsc_translator(self):

--- a/tests/test_translate_header.py
+++ b/tests/test_translate_header.py
@@ -97,7 +97,7 @@ class TestTranslateHeader(unittest.TestCase):
         self.assertEqual(len(failed), 3)
 
     def test_translate_header_traceback(self):
-        """Translate some header files that fail and trigger traceback"""
+        """Translate some header files that fail and trigger traceback."""
         with io.StringIO() as out:
             with io.StringIO() as err:
                 okay, failed = process_files(
@@ -116,7 +116,7 @@ class TestTranslateHeader(unittest.TestCase):
         self.assertEqual(len(failed), 3)
 
     def test_translate_header_dump(self):
-        """Check that a header is dumped"""
+        """Check that a header is dumped."""
         with io.StringIO() as out:
             with io.StringIO() as err:
                 okay, failed = process_files(
@@ -142,7 +142,7 @@ class TestTranslateHeader(unittest.TestCase):
         self.assertEqual(len(failed), 0)
 
     def test_translate_header_loud(self):
-        """Check that ObservationInfo content is displayed"""
+        """Check that ObservationInfo content is displayed."""
         with io.StringIO() as out:
             with io.StringIO() as err:
                 okay, failed = process_files(

--- a/tests/test_translation.py
+++ b/tests/test_translation.py
@@ -20,7 +20,7 @@ TESTDIR = os.path.abspath(os.path.dirname(__file__))
 
 
 class InstrumentTestTranslator(FitsTranslator, StubTranslator):
-    """Simple FITS-like translator to test the infrastructure"""
+    """Simple FITS-like translator to test the infrastructure."""
 
     # Needs a name to be registered
     name = "TestTranslator"
@@ -49,6 +49,8 @@ class MissingMethodsTranslator(FitsTranslator):
 
 
 class TranslatorTestCase(unittest.TestCase):
+    """Test core translation infrastructure."""
+
     def setUp(self):
         # Known simple header
         self.header = {

--- a/tests/test_translation.py
+++ b/tests/test_translation.py
@@ -82,7 +82,8 @@ class TranslatorTestCase(unittest.TestCase):
 
             class InstrumentTestTranslatorExtras(InstrumentTestTranslator):
                 """Version of InstrumentTestTranslator with unexpected
-                fields."""
+                fields.
+                """
 
                 name = "InstrumentTestTranslatorExtras"
                 _trivial_map = {"foobar": "BAZ"}

--- a/types.txt
+++ b/types.txt
@@ -1,2 +1,1 @@
 types-PyYAML
-types-click

--- a/types.txt
+++ b/types.txt
@@ -1,3 +1,2 @@
 types-PyYAML
 types-click
-types-pkg_resources


### PR DESCRIPTION
We could make further switches to `ResourcePath` for locating correction files but this solves the immediate problem of `pkg_resources` being deprecated.