### PR TITLE
DM-55264: Do not require the translator to resolve on deserialization unless there are extensions

### DIFF
--- a/doc/changes/DM-55264.bugfix.rst
+++ b/doc/changes/DM-55264.bugfix.rst
@@ -1,0 +1,2 @@
+Updated the model reader to not require that a translator name be registered.
+The translator class name is purely informational for any ``ObservationInfo`` that does not require extensions.

--- a/python/astro_metadata_translator/observationInfo.py
+++ b/python/astro_metadata_translator/observationInfo.py
@@ -493,9 +493,7 @@ class ObservationInfo(BaseModel):
         # field name directly.
         translator_name = kwargs.pop("_translator", None) or kwargs.pop("translator_name", None)
         supplied_extensions = kwargs.pop("_extensions", None)
-        if translator_name is not None:
-            if translator_name not in MetadataTranslator.translators:
-                raise KeyError(f"Unrecognized translator: {translator_name}")
+        if translator_name is not None and translator_name in MetadataTranslator.translators:
             translator_class = MetadataTranslator.translators[translator_name]
 
         if translator_class is not None and not issubclass(translator_class, MetadataTranslator):
@@ -535,6 +533,13 @@ class ObservationInfo(BaseModel):
             self._translator = translator_class({})
             self._translator_class_name = translator_class.__name__
             self.translator_name = translator_class.name
+        elif translator_name is not None:
+            # The named translator is not registered in this process. The
+            # translator instance is only needed while constructing from a
+            # header, so it is left as None and the name from the serialization
+            # is recorded directly.
+            self._translator_class_name = translator_name
+            self.translator_name = translator_name
 
         self._sealed = True
 

--- a/python/astro_metadata_translator/observationInfo.py
+++ b/python/astro_metadata_translator/observationInfo.py
@@ -509,9 +509,29 @@ class ObservationInfo(BaseModel):
             extensions = translator_class.extensions if translator_class is not None else {}
 
         all_properties = self._get_all_properties(extensions)
-        for key in kwargs:
-            if key not in all_properties:
-                raise KeyError(f"Unrecognized property '{key}' provided")
+        unrecognized = [key for key in kwargs if key not in all_properties]
+        if unrecognized:
+            # Extension properties (the ``ext_`` prefixed keys) are defined by
+            # the translator. When the translator could not be resolved its
+            # extension definitions are unavailable, so report that as the
+            # underlying cause rather than an opaque unknown property.
+            extension_keys = sorted(key for key in unrecognized if key.startswith("ext_"))
+            if extension_keys and translator_class is None:
+                reason = (
+                    f"translator '{translator_name}' is not registered"
+                    if translator_name is not None
+                    else "no translator was specified"
+                )
+                raise KeyError(
+                    f"Unrecognized extension properties {extension_keys}: {reason}, so the "
+                    "extension property definitions are unavailable."
+                )
+            text = (
+                f"property ({unrecognized[0]})"
+                if len(unrecognized) == 1
+                else f"properties ({', '.join(unrecognized)})"
+            )
+            raise KeyError(f"Unrecognized {text} provided")
 
         processed = {k: v for k, v in kwargs.items() if k in PROPERTIES and v is not None}
         processed = self._apply_constructor_defaults(processed, supplied_keys)

--- a/tests/data/obsinfo-extensions-unknown-translator.json
+++ b/tests/data/obsinfo-extensions-unknown-translator.json
@@ -1,0 +1,64 @@
+{
+  "_translator": "fixture_unknown",
+  "altaz_begin": [
+    110.0,
+    65.0
+  ],
+  "altaz_end": [
+    110.5,
+    64.5
+  ],
+  "boresight_airmass": 1.1037,
+  "boresight_rotation_angle": 45.0,
+  "boresight_rotation_coord": "sky",
+  "can_see_sky": true,
+  "dark_time": 31.0,
+  "datetime_begin": [
+    2460817.0,
+    -0.4418402777777778
+  ],
+  "datetime_end": [
+    2460817.0,
+    -0.44149305555555557
+  ],
+  "detector_exposure_id": 98765432142,
+  "detector_group": "R22",
+  "detector_name": "S00",
+  "detector_num": 42,
+  "detector_serial": "ITL-3800C-145",
+  "detector_unique_name": "R22_S00",
+  "exposure_group": "20250521_000123",
+  "exposure_id": 987654321,
+  "exposure_time": 30.0,
+  "exposure_time_requested": 30.0,
+  "ext_foo": "bar",
+  "ext_number": 12345,
+  "focus_z": 0.001,
+  "group_counter_end": 123,
+  "group_counter_start": 123,
+  "has_simulated_content": false,
+  "instrument": "TestCam",
+  "location": [
+    1818938.9432360171,
+    -5208470.950937998,
+    -3195172.084267574
+  ],
+  "object": "HD12345",
+  "observation_counter": 123,
+  "observation_id": "TC_O_20250521_000123",
+  "observation_reason": "science",
+  "observation_type": "science",
+  "observing_day": 20250520,
+  "observing_day_offset": 43200,
+  "physical_filter": "r",
+  "pressure": 750.0,
+  "relative_humidity": 42.5,
+  "science_program": "2025A-001",
+  "telescope": "Test Telescope",
+  "temperature": 283.15,
+  "tracking_radec": [
+    123.456,
+    -45.678
+  ],
+  "visit_id": 987654000
+}

--- a/tests/data/obsinfo-unregistered.json
+++ b/tests/data/obsinfo-unregistered.json
@@ -1,0 +1,62 @@
+{
+  "altaz_begin": [
+    110.0,
+    65.0
+  ],
+  "altaz_end": [
+    110.5,
+    64.5
+  ],
+  "boresight_airmass": 1.1037,
+  "boresight_rotation_angle": 45.0,
+  "boresight_rotation_coord": "sky",
+  "can_see_sky": true,
+  "dark_time": 31.0,
+  "datetime_begin": [
+    2460817.0,
+    -0.4418402777777778
+  ],
+  "datetime_end": [
+    2460817.0,
+    -0.44149305555555557
+  ],
+  "detector_exposure_id": 98765432142,
+  "detector_group": "R22",
+  "detector_name": "S00",
+  "detector_num": 42,
+  "detector_serial": "ITL-3800C-145",
+  "detector_unique_name": "R22_S00",
+  "exposure_group": "20250521_000123",
+  "exposure_id": 987654321,
+  "exposure_time": 30.0,
+  "exposure_time_requested": 30.0,
+  "focus_z": 0.001,
+  "group_counter_end": 123,
+  "group_counter_start": 123,
+  "has_simulated_content": false,
+  "instrument": "TestCam",
+  "location": [
+    1818938.9432360171,
+    -5208470.950937998,
+    -3195172.084267574
+  ],
+  "object": "HD12345",
+  "observation_counter": 123,
+  "observation_id": "TC_O_20250521_000123",
+  "observation_reason": "science",
+  "observation_type": "science",
+  "observing_day": 20250520,
+  "observing_day_offset": 43200,
+  "physical_filter": "r",
+  "pressure": 750.0,
+  "relative_humidity": 42.5,
+  "science_program": "2025A-001",
+  "telescope": "Test Telescope",
+  "temperature": 283.15,
+  "tracking_radec": [
+    123.456,
+    -45.678
+  ],
+  "visit_id": 987654000,
+  "translator_name": "Unregistered"
+}

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -134,9 +134,11 @@ class BasicTestCase(unittest.TestCase):
         with self.assertRaises(ValidationError):
             ObservationInfo.model_validate([])
 
-        with self.assertRaises(KeyError) as cm:
-            ObservationInfo.model_validate({"_translator": "Unknown"})
-        self.assertIn("Unrecognized translator", str(cm.exception))
+        # An unregistered translator name is accepted: the name is retained
+        # but no translator instance is created.
+        unknown = ObservationInfo.model_validate({"_translator": "Unknown"})
+        self.assertEqual(unknown.translator_name, "Unknown")
+        self.assertIsNone(unknown._translator)
 
         with self.assertRaises(KeyError) as cm:
             ObservationInfo.model_validate({"random": "Unknown"})

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -169,6 +169,20 @@ class ObservationInfoSerializationTestCase(unittest.TestCase):
         self.assertEqual(round_tripped.translator_name, "fixture")
         self.assertIn("_translator", obsinfo.model_dump())
 
+        # If there are extension properties the translator must be registered
+        # so that the extension definitions are available. The error must
+        # identify the missing translator as the cause rather than simply
+        # reporting an unknown property.
+        path = os.path.join(DATADIR, "obsinfo-extensions-unknown-translator.json")
+        with open(path) as fh:
+            json_str = fh.read()
+        with self.assertRaises(KeyError) as cm:
+            ObservationInfo.from_json(json_str)
+        message = str(cm.exception)
+        self.assertIn("fixture_unknown", message)
+        self.assertIn("not registered", message)
+        self.assertIn("ext_foo", message)
+
     def test_read_unregistered(self) -> None:
         """Read a serialization with unregistered translator name."""
         path = os.path.join(DATADIR, "obsinfo-unregistered.json")

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -169,6 +169,25 @@ class ObservationInfoSerializationTestCase(unittest.TestCase):
         self.assertEqual(round_tripped.translator_name, "fixture")
         self.assertIn("_translator", obsinfo.model_dump())
 
+    def test_read_unregistered(self) -> None:
+        """Read a serialization with unregistered translator name."""
+        path = os.path.join(DATADIR, "obsinfo-unregistered.json")
+        with open(path) as fh:
+            obsinfo = ObservationInfo.from_json(fh.read())
+
+        self.assertIsInstance(obsinfo, ObservationInfo)
+        self._check_core_properties(obsinfo)
+        # No extensions present in this fixture.
+        self.assertEqual(obsinfo.extensions, {})
+
+        self.assertIsNone(obsinfo._translator, None)
+        self.assertEqual(obsinfo.translator_name, "Unregistered")
+
+        # Round-tripping through JSON should be stable.
+        round_tripped = ObservationInfo.from_json(obsinfo.to_json())
+        self.assertEqual(round_tripped, obsinfo)
+        self.assertEqual(round_tripped.translator_name, "Unregistered")
+
     def test_nested_in_pydantic_model(self) -> None:
         """Nesting in another Pydantic model preserves the wire format.
 

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -130,9 +130,16 @@ class ObservationInfoSerializationTestCase(unittest.TestCase):
         # No extensions present in this fixture.
         self.assertEqual(obsinfo.extensions, {})
 
+        # Translator class is empty.
+        self.assertIsNone(obsinfo._translator)
+        self.assertEqual(obsinfo.translator_class_name, "<None>")
+
         # Round-tripping through JSON should be stable.
         round_tripped = ObservationInfo.from_json(obsinfo.to_json())
         self.assertEqual(round_tripped, obsinfo)
+
+        # Should not include a spurious translator name.
+        self.assertNotIn("_translator", obsinfo.model_dump())
 
     def test_read_full_with_extensions(self) -> None:
         """Read the fixture that also contains extension keys."""
@@ -149,10 +156,18 @@ class ObservationInfoSerializationTestCase(unittest.TestCase):
         self.assertEqual(obsinfo.ext_foo, "bar")
         self.assertEqual(obsinfo.ext_number, 12345)
 
+        self.assertIsInstance(obsinfo._translator, _FixtureTranslator)
+        self.assertEqual(obsinfo.translator_name, "fixture")
+
         round_tripped = ObservationInfo.from_json(obsinfo.to_json())
         self.assertEqual(round_tripped, obsinfo)
         self.assertEqual(round_tripped.ext_foo, "bar")
         self.assertEqual(round_tripped.ext_number, 12345)
+
+        # Should dump the translator name.
+        self.assertIsInstance(round_tripped._translator, _FixtureTranslator)
+        self.assertEqual(round_tripped.translator_name, "fixture")
+        self.assertIn("_translator", obsinfo.model_dump())
 
     def test_nested_in_pydantic_model(self) -> None:
         """Nesting in another Pydantic model preserves the wire format.


### PR DESCRIPTION
* With not extension properties the translator name is purely informational so we should not require that obs_lsst translators be registered.
* With that change we needed to adjust the error reporting for extensions so that people know why they can't read a serialization using extensions (the translator needs to define the extensions).